### PR TITLE
Allow callable instance scope to throw exceptions

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -360,6 +360,9 @@ const auto injector = di::make_injector(
 , di::bind<>.to(42) // renderer device
 );
 ```
+<span class="fa fa-eye wy-text-neutral warning"> **Note**<br/><br/>
+It is safe to throw exceptions from lambda. It will be passed through.
+</span>
 
 Notice, that [injector] was passed to lambda expression in order to create `gui_view` / `text_view`.
 This way `[Boost].DI` can inject appropriate dependencies into chosen types. See [bindings] for more details.

--- a/extension/injections/factory.cpp
+++ b/extension/injections/factory.cpp
@@ -48,7 +48,7 @@ struct factory_impl<TInjector, T, ifactory<I, TArgs...>> : ifactory<I, TArgs...>
 template <class T>
 struct factory {
   template <class TInjector, class TDependency>
-  auto operator()(const TInjector& injector, const TDependency&) const noexcept {
+  auto operator()(const TInjector& injector, const TDependency&) const {
     static auto sp = std::make_shared<factory_impl<TInjector, T, typename TDependency::expected>>(injector);
     return sp;
   }

--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -1471,18 +1471,18 @@ class instance {
     template <class T, class, class TProvider,
               __BOOST_DI_REQUIRES(!detail::is_expr<TGiven, TProvider>::value && aux::is_callable_with<TGiven>::value &&
                                   !aux::is_callable<TExpected>::value) = 0>
-    auto create(const TProvider&) const noexcept {
+    auto create(const TProvider&) const {
       using wrapper = detail::wrapper_traits_t<decltype(aux::declval<TGiven>()())>;
       return wrapper{object_()};
     }
     template <class, class, class TProvider, __BOOST_DI_REQUIRES(detail::is_expr<TGiven, TProvider>::value) = 0>
-    auto create(const TProvider& provider) noexcept {
+    auto create(const TProvider& provider) {
       using wrapper = detail::wrapper_traits_t<decltype((object_)(*provider.injector_))>;
       return wrapper{(object_)(*provider.injector_)};
     }
     template <class T, class, class TProvider,
               __BOOST_DI_REQUIRES(detail::is_expr<TGiven, TProvider, const detail::arg<T, TExpected, TGiven>&>::value) = 0>
-    auto create(const TProvider& provider) noexcept {
+    auto create(const TProvider& provider) {
       using wrapper = detail::wrapper_traits_t<decltype((object_)(*provider.injector_, detail::arg<T, TExpected, TGiven>{}))>;
       return wrapper{(object_)(*provider.injector_, detail::arg<T, TExpected, TGiven>{})};
     }

--- a/include/boost/di/scopes/instance.hpp
+++ b/include/boost/di/scopes/instance.hpp
@@ -172,20 +172,20 @@ class instance {
     template <class T, class, class TProvider,
               __BOOST_DI_REQUIRES(!detail::is_expr<TGiven, TProvider>::value && aux::is_callable_with<TGiven>::value &&
                                   !aux::is_callable<TExpected>::value) = 0>
-    auto create(const TProvider&) const noexcept {
+    auto create(const TProvider&) const {
       using wrapper = detail::wrapper_traits_t<decltype(aux::declval<TGiven>()())>;
       return wrapper{object_()};
     }
 
     template <class, class, class TProvider, __BOOST_DI_REQUIRES(detail::is_expr<TGiven, TProvider>::value) = 0>
-    auto create(const TProvider& provider) noexcept {
+    auto create(const TProvider& provider) {
       using wrapper = detail::wrapper_traits_t<decltype((object_)(*provider.injector_))>;
       return wrapper{(object_)(*provider.injector_)};
     }
 
     template <class T, class, class TProvider,
               __BOOST_DI_REQUIRES(detail::is_expr<TGiven, TProvider, const detail::arg<T, TExpected, TGiven>&>::value) = 0>
-    auto create(const TProvider& provider) noexcept {
+    auto create(const TProvider& provider) {
       using wrapper = detail::wrapper_traits_t<decltype((object_)(*provider.injector_, detail::arg<T, TExpected, TGiven>{}))>;
       return wrapper{(object_)(*provider.injector_, detail::arg<T, TExpected, TGiven>{})};
     }

--- a/test/ft/di_injector_except.cpp
+++ b/test/ft/di_injector_except.cpp
@@ -81,14 +81,16 @@ test should_throw_when_lambda_with_no_args_throws = [] {
 	expect(cought);
 };
 
+struct except_factory {
+  template <class TInjector>
+  auto operator()(const TInjector&) const {
+    throw 0;
+    return empty{};
+  }
+};
+
 test should_throw_when_factory_with_1_arg_throws = [] {
-	struct except_factory {
-		template <class TInjector>
-		auto operator()(const TInjector&) const {
-			throw 0;
-			return empty{};
-		}
-	};
+
 	const auto injector = di::make_injector(di::bind<empty>().to(except_factory{}));
 
 	auto cought = false;

--- a/test/ft/di_injector_except.cpp
+++ b/test/ft/di_injector_except.cpp
@@ -26,3 +26,80 @@ test should_throw_when_ctor_throws = [] {
   }
   expect(cought);
 };
+
+
+struct empty {};
+
+test should_throw_when_lambda_with_2_args_throws = [] {
+
+	const auto injector = di::make_injector(di::bind<empty>().to([](const auto&, const auto&) {
+		throw 0;
+		return empty{};
+	}));
+
+	auto cought = false;
+	try {
+		injector.create<empty>();
+	}
+	catch (...) {
+		cought = true;
+	}
+	expect(cought);
+};
+
+
+
+test should_throw_when_lambda_with_1_arg_throws = [] {
+
+	const auto injector = di::make_injector(di::bind<empty>().to([](const auto&) {
+		throw 0;
+		return empty{};
+	}));
+
+	auto cought = false;
+	try {
+		injector.create<empty>();
+	}
+	catch (...) {
+		cought = true;
+	}
+	expect(cought);
+};
+
+
+test should_throw_when_lambda_with_no_args_throws = [] {
+
+	const auto injector = di::make_injector(di::bind<empty>().to([]() {
+		throw 0;
+		return empty{};
+	}));
+
+	auto cought = false;
+	try {
+		injector.create<empty>();
+	}
+	catch (...) {
+		cought = true;
+	}
+	expect(cought);
+};
+
+test should_throw_when_factory_with_1_arg_throws = [] {
+	struct except_factory {
+		template <class TInjector>
+		auto operator()(const TInjector&) const {
+			throw 0;
+			return empty{};
+		}
+	};
+	const auto injector = di::make_injector(di::bind<empty>().to(except_factory{}));
+
+	auto cought = false;
+	try {
+		injector.create<empty>();
+	}
+	catch (...) {
+		cought = true;
+	}
+	expect(cought);
+};


### PR DESCRIPTION
Details:
Allow callable instance scope to throw exceptions

Test plan: covered with functional tests

Reviwers:
@kris-jusiak @krzysztof-jusiak 