### PR TITLE
Fix of MSVC errors and warnings

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -82,10 +82,12 @@
 
 #include <memory>
 #include <cassert>
+
+#include <boost/di.hpp>
+
 #if __has_include(<boost/shared_ptr.hpp>)
 #include <boost/shared_ptr.hpp>
 #endif
-#include <boost/di.hpp>
 
 namespace di = boost::di;
 

--- a/extension/injections/generics.cpp
+++ b/extension/injections/generics.cpp
@@ -163,7 +163,7 @@ struct has_info__<T, N, valid_t<typename T::template info__<N, void>::type>> : s
     }                                                                                                                   \
   }
 
-template <template <class...> class TWrapper, class T, class... Ts, template <class...> class X, class TScope, class Y>
+template <template <class...> class TWrapper, class T, class... Ts, template <class, class> class X, class TScope, class Y>
 auto generic_cast(const TWrapper<T, X<TScope, Y>>& arg) {
   return arg.wrapper_.operator T();
 }

--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -485,6 +485,10 @@ struct deref_type<std::set<TKey, TCompare, TAllocator>> {
   using type = core::array<remove_qualifiers_t<typename deref_type<TKey>::type>>;
 };
 template <class T>
+struct deref_type<std::initializer_list<T>> {
+  using type = core::array<remove_qualifiers_t<typename deref_type<T>::type>>;
+};
+template <class T>
 using decay_t = typename deref_type<remove_qualifiers_t<T>>::type;
 template <class, class>
 struct is_same : false_type {};

--- a/include/boost/di/aux_/type_traits.hpp
+++ b/include/boost/di/aux_/type_traits.hpp
@@ -214,6 +214,11 @@ struct deref_type<std::set<TKey, TCompare, TAllocator>> {
 };
 
 template <class T>
+struct deref_type<std::initializer_list<T>> {
+  using type = core::array<remove_qualifiers_t<typename deref_type<T>::type>>;
+};
+
+template <class T>
 using decay_t = typename deref_type<remove_qualifiers_t<T>>::type;
 
 template <class, class>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,7 +71,10 @@ test(ft/di_injector)
 test(ft/di_no_memory_inc)
 set_source_files_properties(ft/di_no_std_inc.cpp PROPERTIES COMPILE_FLAGS -DBOOST_DI_TEST_HPP)
 test(ft/di_no_std_inc)
-set_source_files_properties(ft/di_injector_except.cpp PROPERTIES COMPILE_FLAGS -fexceptions)
+
+if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
+    set_source_files_properties(ft/di_injector_except.cpp PROPERTIES COMPILE_FLAGS -fexceptions)
+endif()
 test(ft/di_injector_except)
 
 test(pt/di_compile_time)

--- a/test/ft/di_bind.cpp
+++ b/test/ft/di_bind.cpp
@@ -1142,7 +1142,7 @@ test bind_template_to_type_templates_type = [] {
   expect(42 == object.t.i);
 };
 
-#if not defined(__MSVC__)
+#if !defined(__MSVC__)
 template <class T = class External>
 struct app4 {
   using type = T;

--- a/test/ft/di_errors.cpp
+++ b/test/ft/di_errors.cpp
@@ -727,7 +727,7 @@ test not_configurable_config = [] {
 
 test make_policies_with_non_const_policy = [] {
   auto errors_ = errors("constraint not satisfied",
-#if defined(__MSVC__)
+#if defined(__MSVC__) && _MSC_VER < 1912
                         "policy<.*>::requires_<.*call_operator_with_one_argument>", "=.*non_const_policy"
 #else
                         "policy<.*non_const_policy>::requires_<.*call_operator_with_one_argument>"
@@ -764,7 +764,7 @@ test make_policies_with_non_movable_policy = [] {
 
 test config_wrong_policy = [] {
   auto errors_ = errors("constraint not satisfied",
-#if defined(__MSVC__)
+#if defined(__MSVC__) && _MSC_VER < 1912
                         "policy<.*>::requires_<.*call_operator_with_one_argument>", "=.*int"
 #else
                         "policy<.*int>::requires_<.*call_operator_with_one_argument>"
@@ -784,7 +784,7 @@ int main() { di::make_injector<test_config>(); }
 
     test config_policy_not_callable = [] {
       auto errors_ = errors("constraint not satisfied",
-#if defined(__MSVC__)
+#if defined(__MSVC__) && _MSC_VER < 1912
                             "policy<.*>::requires_<.*call_operator_with_one_argument>", "=.*dummy"
 #else
                             "policy<.*dummy>::requires_<.*call_operator_with_one_argument>"


### PR DESCRIPTION
Proposed changes:
- Fix error of MSVC 2017 updated compiler
- Fix of 4 warnings for MSVC
- Fixed `error` functional test

Reviewvers:
@krzysztof-jusiak 