### PR TITLE
:bug: Support for binding `final` classes

### DIFF
--- a/include/boost/di/aux_/type_traits.hpp
+++ b/include/boost/di/aux_/type_traits.hpp
@@ -357,7 +357,7 @@ struct unique<type<Rs...>> : type_list<Rs...> {};
 template <class... Ts>
 using unique_t = typename unique<type<>, Ts...>::type;
 
-__BOOST_DI_HAS_METHOD(is_callable_with, operator());
+__BOOST_DI_HAS_METHOD(is_invocable, operator());
 
 struct callable_base_impl {
   void operator()(...) {}

--- a/include/boost/di/concepts/boundable.hpp
+++ b/include/boost/di/concepts/boundable.hpp
@@ -115,8 +115,7 @@ struct is_related {
 template <class I, class T>
 struct is_related<true, I, T> {
   static constexpr auto value =
-      aux::is_callable<T>::value ||
-      (aux::is_base_of<I, T>::value || (aux::is_convertible<T, I>::value && !aux::is_narrowed<I, T>::value));
+      aux::is_base_of<I, T>::value || (aux::is_convertible<T, I>::value && !aux::is_narrowed<I, T>::value);
 };
 
 template <bool, class>

--- a/include/boost/di/core/dependency.hpp
+++ b/include/boost/di/core/dependency.hpp
@@ -137,7 +137,7 @@ class dependency
     return dependency{object};
   }
 
-  template <class T, __BOOST_DI_REQUIRES(externable<T>::value) = 0,
+  template <class T, __BOOST_DI_REQUIRES(externable<T>::value && !aux::is_callable<T>::value) = 0,
             __BOOST_DI_REQUIRES_MSG(concepts::boundable<deduce_traits_t<TExpected, T>, aux::decay_t<T>, aux::valid<>>) = 0>
   auto to(T&& object) noexcept {
     using dependency =
@@ -145,8 +145,22 @@ class dependency
     return dependency{static_cast<T&&>(object)};
   }
 
-  template <class TConcept, class T, __BOOST_DI_REQUIRES(externable<T>::value) = 0,
+  template <class T, __BOOST_DI_REQUIRES(externable<T>::value&& aux::is_callable<T>::value) = 0>
+  auto to(T&& object) noexcept {
+    using dependency =
+        dependency<scopes::instance, deduce_traits_t<TExpected, T>, typename ref_traits<T>::type, TName, TPriority>;
+    return dependency{static_cast<T&&>(object)};
+  }
+
+  template <class TConcept, class T, __BOOST_DI_REQUIRES(externable<T>::value && !aux::is_callable<T>::value) = 0,
             __BOOST_DI_REQUIRES_MSG(concepts::boundable<deduce_traits_t<TExpected, T>, aux::decay_t<T>, aux::valid<>>) = 0>
+  auto to(T&& object) noexcept {
+    using dependency = dependency<scopes::instance, deduce_traits_t<concepts::any_of<TExpected, TConcept>, T>,
+                                  typename ref_traits<T>::type, TName, TPriority>;
+    return dependency{static_cast<T&&>(object)};
+  }
+
+  template <class TConcept, class T, __BOOST_DI_REQUIRES(externable<T>::value&& aux::is_callable<T>::value) = 0>
   auto to(T&& object) noexcept {
     using dependency = dependency<scopes::instance, deduce_traits_t<concepts::any_of<TExpected, TConcept>, T>,
                                   typename ref_traits<T>::type, TName, TPriority>;

--- a/include/boost/di/scopes/instance.hpp
+++ b/include/boost/di/scopes/instance.hpp
@@ -41,9 +41,9 @@ using wrapper_traits_t = typename wrapper_traits<T>::type;
 __BOOST_DI_HAS_TYPE(has_result_type, result_type);
 
 template <class TGiven, class TProvider, class... Ts>
-struct is_expr : aux::integral_constant<bool,
-                                        aux::is_callable_with<TGiven, typename TProvider::injector_t, Ts...>::value &&
-                                            !has_result_type<TGiven>::value> {};
+struct is_expr
+    : aux::integral_constant<
+          bool, aux::is_invocable<TGiven, typename TProvider::injector_t, Ts...>::value && !has_result_type<TGiven>::value> {};
 
 }  // detail
 
@@ -146,7 +146,7 @@ class instance {
     static wrappers::unique<instance, TExpected> try_create(const TProvider&) noexcept;
 
     template <class T, class, class TProvider,
-              __BOOST_DI_REQUIRES(!detail::is_expr<TGiven, TProvider>::value && aux::is_callable_with<TGiven>::value &&
+              __BOOST_DI_REQUIRES(!detail::is_expr<TGiven, TProvider>::value && aux::is_invocable<TGiven>::value &&
                                   !aux::is_callable<TExpected>::value) = 0>
     static auto try_create(const TProvider&) noexcept
         -> detail::wrapper_traits_t<decltype(aux::declval<typename aux::identity<TGiven, T>::type>()())>;
@@ -170,7 +170,7 @@ class instance {
     }
 
     template <class T, class, class TProvider,
-              __BOOST_DI_REQUIRES(!detail::is_expr<TGiven, TProvider>::value && aux::is_callable_with<TGiven>::value &&
+              __BOOST_DI_REQUIRES(!detail::is_expr<TGiven, TProvider>::value && aux::is_invocable<TGiven>::value &&
                                   !aux::is_callable<TExpected>::value) = 0>
     auto create(const TProvider&) const {
       using wrapper = detail::wrapper_traits_t<decltype(aux::declval<TGiven>()())>;


### PR DESCRIPTION
Problem:
- Classes marked `final` can't be bound because `is_callable` requires inheritance.
- `is_callable` has been changed by ISO committee to `is_invocable`.

Solution:
- Ignore `boundable` concept verification (it will be checked by `creatable` concept later on) if bound type is callable.
- Rename `is_callable_with` to `is_invocable`.