### PR TITLE
:new: :art: Generalize resolving and accessing dependencies

### DIFF
--- a/extension/include/boost/di/extension/injections/extensible_injector.hpp
+++ b/extension/include/boost/di/extension/injections/extensible_injector.hpp
@@ -11,19 +11,20 @@
 BOOST_DI_NAMESPACE_BEGIN
 namespace extension {
 
-template <class TDependency>
-class dependency_proxy
-    : core::dependency_base,
-      public core::dependency_impl<core::dependency_concept<typename TDependency::expected, typename TDependency::name>,
-                                   dependency_proxy<TDependency>> {
- public:
-  using scope = typename TDependency::scope;
-  using expected = typename TDependency::expected;
-  using given = typename TDependency::given;
-  using name = typename TDependency::name;
-  using priority = typename TDependency::priority;
+template <class TScope, class TExpected, class TGiven, class TName, class TPriority>
+class dependency_proxy : core::dependency_base,
+                         public core::dependency_impl<core::dependency_concept<TExpected, TName>,
+                                                      dependency_proxy<TScope, TExpected, TGiven, TName, TPriority>> {
+  using dependency_t = core::dependency<TScope, TExpected, TGiven, TName, TPriority>;
 
-  dependency_proxy(TDependency& orig_dependency) noexcept : orig_dependency_(orig_dependency) {}
+ public:
+  using scope = TScope;
+  using expected = TExpected;
+  using given = TGiven;
+  using name = TName;
+  using priority = TPriority;
+
+  dependency_proxy(dependency_t& orig_dependency) noexcept : orig_dependency_(orig_dependency) {}
 
   dependency_proxy(dependency_proxy& other) noexcept : orig_dependency_(other.orig_dependency_) {}
   dependency_proxy(dependency_proxy&& other) noexcept : orig_dependency_(other.orig_dependency_) {}
@@ -34,22 +35,22 @@ class dependency_proxy
   template <class T>
   using is_referable = typename scope_t::template is_referable<T>;
 
-  template <class T, class TName, class TProvider>
-  static decltype(scope_t::template try_create<T, TName>(aux::declval<TProvider>())) try_create(const TProvider&);
+  template <class T, class Name, class TProvider>
+  static decltype(scope_t::template try_create<T, Name>(aux::declval<TProvider>())) try_create(const TProvider&);
 
-  template <class T, class TName, class TProvider>
+  template <class T, class Name, class TProvider>
   auto create(const TProvider& provider) {
-    return static_cast<core::dependency__<TDependency>&>(orig_dependency_).template create<T, TName>(provider);
+    return static_cast<core::dependency__<dependency_t>&>(orig_dependency_).template create<T, Name>(provider);
   }
 
  private:
-  TDependency& orig_dependency_;
+  dependency_t& orig_dependency_;
 };
 
 template <class TDependency, class TInjector>
 auto make_extensible_impl(const aux::type<TDependency>&, TInjector& injector) {
-  auto& dependency = core::binder::resolve<typename TDependency::expected, typename TDependency::name>(&injector);
-  return dependency_proxy<TDependency>{dependency};
+  return dependency_proxy<typename TDependency::scope, typename TDependency::expected, typename TDependency::given,
+                          typename TDependency::name, typename TDependency::priority>{injector};
 }
 
 template <class... TDeps, class TInjector>

--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -1980,18 +1980,20 @@ struct binder {
   static decltype(auto) resolve_impl(aux::pair<TConcept, TDependency>* dep) noexcept {
     return static_cast<TDependency&>(*dep);
   }
-  template <class, class TConcept, class TScope, class TExpected, class TGiven, class TName>
+  template <class, class TConcept, class TScope, class TExpected, class TGiven, class TName,
+            template <class...> class TDependency>
   static decltype(auto) resolve_impl(
-      aux::pair<TConcept, dependency<TScope, TExpected, TGiven, TName, override>>* dep) noexcept {
-    return static_cast<dependency<TScope, TExpected, TGiven, TName, override>&>(*dep);
+      aux::pair<TConcept, TDependency<TScope, TExpected, TGiven, TName, override>>* dep) noexcept {
+    return static_cast<TDependency<TScope, TExpected, TGiven, TName, override>&>(*dep);
   }
   template <class TDefault, class>
   static TDefault resolve_impl__(...);
   template <class, class TConcept, class TDependency>
   static TDependency resolve_impl__(aux::pair<TConcept, TDependency>*);
-  template <class, class TConcept, class TScope, class TExpected, class TGiven, class TName>
+  template <class, class TConcept, class TScope, class TExpected, class TGiven, class TName,
+            template <class...> class TDependency>
   static dependency<TScope, TExpected, TGiven, TName, override> resolve_impl__(
-      aux::pair<TConcept, dependency<TScope, TExpected, TGiven, TName, override>>*);
+      aux::pair<TConcept, TDependency<TScope, TExpected, TGiven, TName, override>>*);
   template <class TDeps, class T, class TName, class TDefault>
   struct resolve__ {
     using type = decltype(resolve_impl__<TDefault, dependency_concept<aux::decay_t<T>, TName>>((TDeps*)0));
@@ -2409,10 +2411,7 @@ inline auto build(TInjector&& injector) noexcept {
 }
 #endif
 template <class TConfig, class TPolicies = pool<>, class... TDeps>
-class injector : injector_base, pool<bindings_t<TDeps...>> {
-  friend struct binder;
-  template <class>
-  friend struct pool;
+class injector : injector_base, public pool<bindings_t<TDeps...>> {
   using pool_t = pool<bindings_t<TDeps...>>;
 
  protected:
@@ -2609,10 +2608,7 @@ class injector : injector_base, pool<bindings_t<TDeps...>> {
   }
 };
 template <class TConfig, class... TDeps>
-class injector<TConfig, pool<>, TDeps...> : injector_base, pool<bindings_t<TDeps...>> {
-  friend struct binder;
-  template <class>
-  friend struct pool;
+class injector<TConfig, pool<>, TDeps...> : injector_base, public pool<bindings_t<TDeps...>> {
   using pool_t = pool<bindings_t<TDeps...>>;
 
  protected:

--- a/include/boost/di/core/binder.hpp
+++ b/include/boost/di/core/binder.hpp
@@ -25,10 +25,11 @@ struct binder {
     return static_cast<TDependency&>(*dep);
   }
 
-  template <class, class TConcept, class TScope, class TExpected, class TGiven, class TName>
+  template <class, class TConcept, class TScope, class TExpected, class TGiven, class TName,
+            template <class...> class TDependency>
   static decltype(auto) resolve_impl(
-      aux::pair<TConcept, dependency<TScope, TExpected, TGiven, TName, override>>* dep) noexcept {
-    return static_cast<dependency<TScope, TExpected, TGiven, TName, override>&>(*dep);
+      aux::pair<TConcept, TDependency<TScope, TExpected, TGiven, TName, override>>* dep) noexcept {
+    return static_cast<TDependency<TScope, TExpected, TGiven, TName, override>&>(*dep);
   }
 
   template <class TDefault, class>
@@ -37,9 +38,10 @@ struct binder {
   template <class, class TConcept, class TDependency>
   static TDependency resolve_impl__(aux::pair<TConcept, TDependency>*);
 
-  template <class, class TConcept, class TScope, class TExpected, class TGiven, class TName>
+  template <class, class TConcept, class TScope, class TExpected, class TGiven, class TName,
+            template <class...> class TDependency>
   static dependency<TScope, TExpected, TGiven, TName, override> resolve_impl__(
-      aux::pair<TConcept, dependency<TScope, TExpected, TGiven, TName, override>>*);
+      aux::pair<TConcept, TDependency<TScope, TExpected, TGiven, TName, override>>*);
 
   template <class TDeps, class T, class TName, class TDefault>
   struct resolve__ {

--- a/include/boost/di/core/injector.hpp
+++ b/include/boost/di/core/injector.hpp
@@ -70,10 +70,8 @@ inline auto build(TInjector&& injector) noexcept {
 #endif
 
 template <class TConfig __BOOST_DI_CORE_INJECTOR_POLICY(, class TPolicies = pool<>)(), class... TDeps>
-class injector __BOOST_DI_CORE_INJECTOR_POLICY()(<TConfig, pool<>, TDeps...>) : injector_base, pool<bindings_t<TDeps...>> {
-  friend struct binder;
-  template <class>
-  friend struct pool;
+class injector __BOOST_DI_CORE_INJECTOR_POLICY()(<TConfig, pool<>, TDeps...>)
+    : injector_base, public pool<bindings_t<TDeps...>> {
   using pool_t = pool<bindings_t<TDeps...>>;
 
  protected:


### PR DESCRIPTION
Problem:
- core::dependency is coupled to the binder making it impossible to use with custom types.
- pool is not exposed from the injector making it impossible to explicitly cast.
- extensible_injector is suffering from the above.

Solution:
- Use template class to generalize binder to be able to resolve with any type which satisfies dependency requirements.
- Inherit pool publicly in the injector. That's okay as to use the underlying dependency an explicit static cast has to be used (or implicit conversion to a di aware type). That's make it use to use by extensions and doesn't expose implementation details to the clients.
- Apply the newest changes to the extensible_injector.

Issue: #

Proposed changes:
-
-

Thread/exception safety:


Reviewvers:
@