### PR TITLE
:art: Move scopes object into scopes files

### DIFF
--- a/extension/include/boost/di/extension/scopes/shared.hpp
+++ b/extension/include/boost/di/extension/scopes/shared.hpp
@@ -29,7 +29,7 @@ class shared {
 #if !defined(BOOST_DI_NOT_THREAD_SAFE)
     //<<lock mutex so that move will be synchronized>>
     explicit scope(scope&& other) noexcept : scope(std::move(other), std::lock_guard<std::mutex>(other.mutex_)) {}
-    //<<syncronized move constructor>>
+    //<<synchronized move constructor>>
     scope(scope&& other, const std::lock_guard<std::mutex>&) noexcept : object_(std::move(other.object_)) {}
 #endif
 

--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -1093,6 +1093,7 @@ class deduce {
   };
 };
 }
+static constexpr __BOOST_DI_UNUSED scopes::deduce deduce{};
 namespace concepts {
 template <class T>
 struct abstract_type {
@@ -1828,6 +1829,7 @@ class singleton {
   };
 };
 }
+static constexpr __BOOST_DI_UNUSED scopes::singleton singleton{};
 namespace scopes {
 class unique {
  public:
@@ -1850,6 +1852,7 @@ class unique {
   };
 };
 }
+static constexpr __BOOST_DI_UNUSED scopes::unique unique{};
 namespace type_traits {
 template <class T>
 struct scope_traits {
@@ -1921,9 +1924,6 @@ struct bind :
 #endif
 {};
 static constexpr __BOOST_DI_UNUSED core::override override{};
-static constexpr __BOOST_DI_UNUSED scopes::deduce deduce{};
-static constexpr __BOOST_DI_UNUSED scopes::unique unique{};
-static constexpr __BOOST_DI_UNUSED scopes::singleton singleton{};
 namespace concepts {
 struct get {};
 struct is_creatable {};

--- a/include/boost/di/bindings.hpp
+++ b/include/boost/di/bindings.hpp
@@ -50,8 +50,5 @@ struct bind :
 {};
 
 static constexpr __BOOST_DI_UNUSED core::override override{};
-static constexpr __BOOST_DI_UNUSED scopes::deduce deduce{};
-static constexpr __BOOST_DI_UNUSED scopes::unique unique{};
-static constexpr __BOOST_DI_UNUSED scopes::singleton singleton{};
 
 #endif

--- a/include/boost/di/scopes/deduce.hpp
+++ b/include/boost/di/scopes/deduce.hpp
@@ -6,6 +6,7 @@
 #ifndef BOOST_DI_SCOPES_DEDUCE_HPP
 #define BOOST_DI_SCOPES_DEDUCE_HPP
 
+#include "boost/di/aux_/compiler.hpp"
 #include "boost/di/aux_/type_traits.hpp"
 
 namespace scopes {
@@ -34,5 +35,7 @@ class deduce {
 };
 
 }  // scopes
+
+static constexpr __BOOST_DI_UNUSED scopes::deduce deduce{};
 
 #endif

--- a/include/boost/di/scopes/singleton.hpp
+++ b/include/boost/di/scopes/singleton.hpp
@@ -7,6 +7,7 @@
 #ifndef BOOST_DI_SCOPES_SINGLETON_HPP
 #define BOOST_DI_SCOPES_SINGLETON_HPP
 
+#include "boost/di/aux_/compiler.hpp"
 #include "boost/di/aux_/type_traits.hpp"
 #include "boost/di/type_traits/memory_traits.hpp"  // type_traits::stack
 #include "boost/di/wrappers/shared.hpp"
@@ -63,5 +64,7 @@ class singleton {
 };
 
 }  // scopes
+
+static constexpr __BOOST_DI_UNUSED scopes::singleton singleton{};
 
 #endif

--- a/include/boost/di/scopes/unique.hpp
+++ b/include/boost/di/scopes/unique.hpp
@@ -7,6 +7,7 @@
 #ifndef BOOST_DI_SCOPES_UNIQUE_HPP
 #define BOOST_DI_SCOPES_UNIQUE_HPP
 
+#include "boost/di/aux_/compiler.hpp"
 #include "boost/di/wrappers/unique.hpp"
 
 namespace scopes {
@@ -35,5 +36,7 @@ class unique {
 };
 
 }  // scopes
+
+static constexpr __BOOST_DI_UNUSED scopes::unique unique{};
 
 #endif


### PR DESCRIPTION
Problem:
- Scopes objects are instantiated in bindings file which is confusing.

Solution:
- Move scopes instantiations into scope files.

Issue: #

Proposed changes:
-
-

Thread/exception safety:


Reviewvers:
@