### PR TITLE
:new: Allow binding multiple empty injectors

### DIFF
--- a/include/boost/di/aux_/type_traits.hpp
+++ b/include/boost/di/aux_/type_traits.hpp
@@ -380,6 +380,18 @@ aux::true_type is_callable_impl(...);
 template <class T>
 struct is_callable : decltype(is_callable_impl((callable_base<T>*)0)) {};
 
+template <class, class = int>
+struct is_empty_expr : false_type {};
+
+template <class TExpr>
+#if defined(__MSVC__)  // __pph__
+struct is_empty_expr<TExpr, valid_t<decltype(declval<TExpr>()())>> : integral_constant<bool, sizeof(TExpr) == 1> {
+};
+#else  // __pph__
+struct is_empty_expr<TExpr, valid_t<decltype(+declval<TExpr>()), decltype(declval<TExpr>()())>> : true_type {
+};
+#endif  // __pph__
+
 template <class>
 struct function_traits;
 

--- a/include/boost/di/aux_/utility.hpp
+++ b/include/boost/di/aux_/utility.hpp
@@ -4,8 +4,8 @@
 // Distributed under the Boost Software type_listicense, Version 1.0.
 // (See accompanying file type_listICENSE_1_0.txt or copy at http://www.boost.org/type_listICENSE_1_0.txt)
 //
-#ifndef BOOST_DI_AUX_UTItype_listITY_HPP
-#define BOOST_DI_AUX_UTItype_listITY_HPP
+#ifndef BOOST_DI_AUX_UTILITY_HPP
+#define BOOST_DI_AUX_UTILITY_HPP
 
 struct _ {
   _(...) {}

--- a/include/boost/di/concepts/boundable.hpp
+++ b/include/boost/di/concepts/boundable.hpp
@@ -41,10 +41,12 @@ template <class...>
 struct any_of : aux::false_type {};
 
 template <class... TDeps>
-struct is_supported : aux::is_same<aux::bool_list<aux::always<TDeps>::value...>,
-                                   aux::bool_list<(aux::is_constructible<TDeps, TDeps&&>::value &&
-                                                   (aux::is_a<core::injector_base, TDeps>::value ||
-                                                    aux::is_a<core::dependency_base, TDeps>::value))...>> {};
+struct is_supported
+    : aux::is_same<aux::bool_list<aux::always<TDeps>::value...>,
+                   aux::bool_list<(aux::is_constructible<TDeps, TDeps&&>::value &&
+                                   (aux::is_a<core::injector_base, TDeps>::value ||
+                                    aux::is_a<core::dependency_base, TDeps>::value || aux::is_empty_expr<TDeps>::value))...>> {
+};
 
 template <class...>
 struct get_not_supported;

--- a/test/ft/di_bind.cpp
+++ b/test/ft/di_bind.cpp
@@ -1208,6 +1208,17 @@ test bind_final_class_callable = [] {
   expect(42 == injector.create<int>());
 };
 
+test bind_multiple_empty_injectors = [] {
+  auto i1 = di::make_injector();
+  const auto module1 = [] { return [] {}; };
+  const auto module2 = [] { return di::make_injector([] {}); };
+
+  const auto injector =
+      di::make_injector([] {}, [] {}, di::make_injector([] {}), std::move(i1), di::make_injector([] {}), module1(), module2());
+
+  expect(0 == injector.create<int>());
+};
+
 #if defined(__cpp_variable_templates)
 test bind_mix = [] {
   constexpr auto i = 42;

--- a/test/ut/aux_/type_traits.cpp
+++ b/test/ut/aux_/type_traits.cpp
@@ -282,4 +282,23 @@ test is_array_types = [] {
   static_expect(is_array<int* []>::value);
 };
 
+test is_empty_expr_types = [] {
+  struct c {};
+  auto empty = [] {};
+  const auto const_empty = [] {};
+  const auto const_args = [](int) {};
+  auto init = [i = 0]{};
+  int _{};
+  auto capture = [_] {};
+
+  static_expect(!is_empty_expr<c>::value);
+  static_expect(!is_empty_expr<void>::value);
+  static_expect(!is_empty_expr<int>::value);
+  static_expect(is_empty_expr<decltype(empty)>::value);
+  static_expect(is_empty_expr<decltype(const_empty)>::value);
+  static_expect(!is_empty_expr<decltype(const_args)>::value);
+  static_expect(!is_empty_expr<decltype(init)>::value);
+  static_expect(!is_empty_expr<decltype(capture)>::value);
+};
+
 }  // aux

--- a/test/ut/concepts/boundable.cpp
+++ b/test/ut/concepts/boundable.cpp
@@ -45,8 +45,10 @@ test bind_any_of = [] {
 };
 
 test bind_deps = [] {
+  const auto empty_expr = [] {};
   static_expect(boundable<aux::type_list<>>::value);
   static_expect(boundable<aux::type_list<fake_dependency<int>>>::value);
+  static_expect(boundable<aux::type_list<decltype(empty_expr)>>::value);
   static_expect(std::is_same<type_<int>::is_bound_more_than_once,
                              boundable<aux::type_list<fake_dependency<int>, fake_dependency<int>>>>::value);
   static_expect(


### PR DESCRIPTION
Problem:
- When using if constexpr it's often a case to return an empty injector without any bindings.
  However, only ONE empty injector can be bound.

Solution:
- Allow `[]{}` or `make_injector([]{})` (both have guaranteed unique types) to be bound multiple times.

Problem:
-

Solution:
-

Issue: #

Reviewers:
@