### PR TITLE
:books: [travis] Fix mkdocs installing issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -189,7 +189,7 @@ script:
   - if [ "${CXX}" != "" ]; then (travis_wait make all); fi
   - if [ "${CHECK}" != "" ]; then (travis_wait make check); fi
   - if [ "${TRAVIS_PULL_REQUEST}" == "false" ] && [ "${TRAVIS_BRANCH}" == "cpp14" ] && [ "${DOCUMENTATION}" != "" ]; then (
-    pip install https://github.com/mkdocs/mkdocs/archive/b30f38fe299738e8ce614e53c3342cc8bef02b5b.zip -U --user
+    pip install tornado==4.5.3 https://github.com/mkdocs/mkdocs/archive/b30f38fe299738e8ce614e53c3342cc8bef02b5b.zip -U --user
     && git clone https://github.com/boost-experimental/di && cd di && rm -rf *
     && git checkout -b gh-pages -t origin/gh-pages && git reset --hard && cd ..
     && MKDOCS_THEME=boost-experimental MKDOCS_SITE=../di make doc


### PR DESCRIPTION
Problem:
- ImportError: Tornado requires an up-to-date SSL module. This means Python 2.7.9+ or 3.4+ (although some distributions have backported the necessary changes to older versions).

Solution:
- Force install tornado==4.5.3.
