### PR TITLE
:art: [example] Rename Example to App

### DIFF
--- a/example/polymorphism/concepts.cpp
+++ b/example/polymorphism/concepts.cpp
@@ -18,12 +18,11 @@ concept bool Drawable = not boost::di::aux::is_complete<T>::value or requires(T 
   t.draw(out);
 };
 
-/*<<Static polymorphism - templates>>*/
+/*<<Static polymorphism - concepts>>*/
 template <Drawable TDrawable = class Drawable>  // requires Drawable<TDrawable>
-class Example {
+class App {
  public:
-  explicit Example(const TDrawable drawable) : drawable(drawable) {}
-
+  explicit App(const TDrawable drawable) : drawable{drawable} {}
   void draw(std::ostream& out) const { drawable.draw(out); }
 
  private:
@@ -40,7 +39,7 @@ struct Circle {
 
 int main() {
   std::stringstream str{};
-  auto example = config().create<Example>();
+  auto example = config().create<App>();
   example.draw(str);
   assert("Square" == str.str());
 }

--- a/example/polymorphism/inheritance.cpp
+++ b/example/polymorphism/inheritance.cpp
@@ -17,10 +17,9 @@ class Drawable {
   virtual void draw(std::ostream&) const = 0;
 };
 
-class Example {
+class App {
  public:
-  explicit Example(std::unique_ptr<const Drawable> drawable) : drawable{std::move(drawable)} {}
-
+  explicit App(std::unique_ptr<const Drawable> drawable) : drawable{std::move(drawable)} {}
   void draw(std::ostream& out) const { drawable->draw(out); }
 
  private:
@@ -37,7 +36,7 @@ struct Circle : Drawable {
 
 int main() {
   std::stringstream str{};
-  auto example = config().create<Example>();
+  auto example = config().create<App>();
   example.draw(str);
   assert("Square" == str.str());
 }

--- a/example/polymorphism/templates.cpp
+++ b/example/polymorphism/templates.cpp
@@ -11,10 +11,9 @@
 
 /*<<Static polymorphism - templates>>*/
 template <typename TDrawable = class Drawable>
-class Example {
+class App {
  public:
-  explicit Example(const TDrawable drawable) : drawable(drawable) {}
-
+  explicit App(const TDrawable drawable) : drawable(drawable) {}
   void draw(std::ostream& out) const { drawable.draw(out); }
 
  private:
@@ -31,7 +30,7 @@ struct Circle {
 
 int main() {
   std::stringstream str{};
-  auto example = config().create<Example>();
+  auto example = config().create<App>();
   example.draw(str);
   assert("Square" == str.str());
 }

--- a/example/polymorphism/type_erasure.cpp
+++ b/example/polymorphism/type_erasure.cpp
@@ -23,10 +23,9 @@ class Drawable {
   std::function<void(std::ostream&)> draw;
 };
 
-class Example {
+class App {
  public:
-  explicit Example(const Drawable drawable) : drawable{drawable} {}
-
+  explicit App(const Drawable drawable) : drawable{drawable} {}
   void draw(std::ostream& out) const { drawable.draw(out); }
 
  private:
@@ -43,7 +42,7 @@ struct Circle {
 
 int main() {
   std::stringstream str{};
-  auto example = config().create<Example>();
+  auto example = config().create<App>();
   example.draw(str);
   assert("Square" == str.str());
 }

--- a/example/polymorphism/variant.cpp
+++ b/example/polymorphism/variant.cpp
@@ -25,9 +25,9 @@ class Drawable : public std::variant<Square, Circle> {
 };
 
 /*<<Variant>>*/
-class Example {
+class App {
  public:
-  explicit Example(const Drawable drawable) : drawable{drawable} {}
+  explicit App(const Drawable drawable) : drawable{drawable} {}
 
   void draw(std::ostream& out) const {
     std::visit([&out](const auto& drawable) { drawable.draw(out); }, drawable);
@@ -39,7 +39,7 @@ class Example {
 
 int main() {
   std::stringstream str{};
-  auto example = config().create<Example>();
+  auto example = config().create<App>();
   example.draw(str);
   assert("Square" == str.str());
 }


### PR DESCRIPTION
Problem:
- Polymorhpism examples are using Example as a name of the App which is confusing.

Solution:
- Use App instead.