### PR TITLE
:bug: Fix #335 - Template binding std::vector

### DIFF
--- a/example/user_guide/annotated_constructor_injection_with_ctor_traits.cpp
+++ b/example/user_guide/annotated_constructor_injection_with_ctor_traits.cpp
@@ -26,8 +26,8 @@ template <>
 struct ctor_traits<T> {
   BOOST_DI_INJECT_TRAITS((named = int1) int, (named = int2) int);
 };
-}
-}  // boost::di
+}  // namespace di
+}  // namespace boost
 
 int main() {
   // clang-format off

--- a/example/user_guide/constructor_injection_ambiguous_constructors_via_ctor_traits.cpp
+++ b/example/user_guide/constructor_injection_ambiguous_constructors_via_ctor_traits.cpp
@@ -25,8 +25,8 @@ template <>
 struct ctor_traits<T> {
   BOOST_DI_INJECT_TRAITS(int, double);
 };
-}
-}  // boost::di
+}  // namespace di
+}  // namespace boost
 
 int main() {
   // clang-format off

--- a/extension/include/boost/di/extension/bindings/constructor_bindings.hpp
+++ b/extension/include/boost/di/extension/bindings/constructor_bindings.hpp
@@ -26,5 +26,5 @@ struct constructor_impl {
 template <class... TCtor>
 struct constructor : constructor_impl<TCtor...> {};
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/bindings/contextual_bindings.hpp
+++ b/extension/include/boost/di/extension/bindings/contextual_bindings.hpp
@@ -66,5 +66,5 @@ class contextual_bindings : public config {
   }
 };
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/injections/assisted_injection.hpp
+++ b/extension/include/boost/di/extension/injections/assisted_injection.hpp
@@ -94,5 +94,5 @@ class assisted_injection_impl {
 template <class T>
 struct assisted_injection : assisted_injection_impl<T> {};
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/injections/concepts.hpp
+++ b/extension/include/boost/di/extension/injections/concepts.hpp
@@ -151,5 +151,5 @@ class concepts_provider_config : public config {
   static auto provider(...) noexcept { return concepts_provider{}; }
 };
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/injections/extensible_injector.hpp
+++ b/extension/include/boost/di/extension/injections/extensible_injector.hpp
@@ -63,5 +63,5 @@ auto make_extensible(TInjector& injector) {
   return make_extensible(typename TInjector::deps{}, injector);
 }
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/injections/factory.hpp
+++ b/extension/include/boost/di/extension/injections/factory.hpp
@@ -55,5 +55,5 @@ struct factory {
   }
 };
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/injections/lazy.hpp
+++ b/extension/include/boost/di/extension/injections/lazy.hpp
@@ -32,5 +32,5 @@ class lazy {
   T (*f)(const void *) = nullptr;
 };
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/injections/named_parameters.hpp
+++ b/extension/include/boost/di/extension/injections/named_parameters.hpp
@@ -143,5 +143,5 @@ auto ctor__(int) -> decltype(&T::ctor);
   };                                                                                                             \
   T(__VA_ARGS__)
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/injections/shared_factory.hpp
+++ b/extension/include/boost/di/extension/injections/shared_factory.hpp
@@ -103,5 +103,5 @@ auto conditional_shared_factory(TFunc condition_func) {
   });
 }
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/injections/xml_injection.hpp
+++ b/extension/include/boost/di/extension/injections/xml_injection.hpp
@@ -49,5 +49,5 @@ class inject_from_xml {
 template <class... TImpl>
 struct xml : inject_from_xml<TImpl...> {};
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/policies/serialize.hpp
+++ b/extension/include/boost/di/extension/policies/serialize.hpp
@@ -177,5 +177,5 @@ auto deserialize = [](const auto& injector, auto& str) {
   });
 };
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/policies/types_dumper.hpp
+++ b/extension/include/boost/di/extension/policies/types_dumper.hpp
@@ -49,5 +49,5 @@ class types_dumper : public config {
   }
 };
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/policies/uml_dumper.hpp
+++ b/extension/include/boost/di/extension/policies/uml_dumper.hpp
@@ -53,5 +53,5 @@ class uml_dumper : public config {
   }
 };
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/providers/heap.hpp
+++ b/extension/include/boost/di/extension/providers/heap.hpp
@@ -29,5 +29,5 @@ class heap {
   }
 };
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/providers/mocks_provider.hpp
+++ b/extension/include/boost/di/extension/providers/mocks_provider.hpp
@@ -142,5 +142,5 @@ auto& expect(TInjector& injector, R (T::*)(TArgs...)) {
   return expectations;
 }
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/scopes/scoped.hpp
+++ b/extension/include/boost/di/extension/scopes/scoped.hpp
@@ -53,9 +53,9 @@ class scoped {
     std::shared_ptr<T> *object_ = nullptr;
   };
 };
-}  // detail
+}  // namespace detail
 
 static constexpr detail::scoped scoped{};
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/scopes/session.hpp
+++ b/extension/include/boost/di/extension/scopes/session.hpp
@@ -59,12 +59,12 @@ class session {
     return is_in_session;
   }
 };
-}  // detail
+}  // namespace detail
 
 template <class TName, class TScope = scopes::singleton>
 auto session(const TName&, const TScope& = {}) {
   return detail::session<TName, TScope>{};
 }
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/extension/include/boost/di/extension/scopes/shared.hpp
+++ b/extension/include/boost/di/extension/scopes/shared.hpp
@@ -78,7 +78,7 @@ class shared {
     std::shared_ptr<T> object_;  /// used by `in(shared)`, otherwise destroyed immediately
   };
 };
-}  // detail
+}  // namespace detail
 
 static constexpr detail::shared shared{};
 
@@ -127,5 +127,5 @@ class shared_config : public di::config {
   std::unordered_map<std::size_t, std::shared_ptr<void>> data_{};
 };
 
-}  // extension
+}  // namespace extension
 BOOST_DI_NAMESPACE_END

--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -292,23 +292,23 @@ struct dependency_base {};
 struct injector_base {};
 template <class T>
 struct dependency__ : T {
-  using T::try_create;
-  using T::is_referable;
   using T::create;
+  using T::is_referable;
+  using T::try_create;
 };
 template <class T>
 struct injector__ : T {
+  using T::cfg;
   using T::create_impl;
   using T::create_successful_impl;
-  using T::cfg;
 #if defined(__MSVC__)
   template <class... Ts>
   using is_creatable = typename T::template is_creatable<Ts...>;
   template <class... Ts>
   using try_create = typename T::template try_create<Ts...>;
 #else
-  using T::try_create;
   using T::is_creatable;
+  using T::try_create;
 #endif
 };
 template <class, class...>
@@ -783,8 +783,8 @@ using boundable_impl__ = aux::conditional_t<
     aux::conditional_t<is_abstract<aux::is_complete<T>::value, T>::value, typename type_<T>::is_abstract, aux::true_type>,
     typename type_<T>::template is_not_related_to<I>>;
 template <class I, class T>
-auto boundable_impl(I&&, T &&) -> aux::conditional_t<aux::is_same<T, aux::decay_t<T>>::value, boundable_impl__<I, T>,
-                                                     typename type_<T>::has_disallowed_qualifiers>;
+auto boundable_impl(I&&, T &&) -> aux::conditional_t<aux::is_same<T, aux::decay_t<T>>::value || !aux::is_complete<I>::value,
+                                                     boundable_impl__<I, T>, typename type_<T>::has_disallowed_qualifiers>;
 template <class I, class T>
 auto boundable_impl(I&&, T&&, aux::valid<> &&)
     -> aux::conditional_t<is_related<aux::is_complete<I>::value && aux::is_complete<T>::value, I, T>::value, aux::true_type,
@@ -1704,8 +1704,8 @@ class dependency
   dependency& operator()() noexcept { return *this; }
 #endif
  protected:
-  using scope_t::is_referable;
   using scope_t::create;
+  using scope_t::is_referable;
   using scope_t::try_create;
   template <class, class>
   static void try_create(...);

--- a/include/boost/di/aux_/type_traits.hpp
+++ b/include/boost/di/aux_/type_traits.hpp
@@ -422,6 +422,6 @@ struct function_traits<R (T::*)(TArgs...) const> {
 template <class T>
 using function_traits_t = typename function_traits<T>::args;
 
-}  // aux
+}  // namespace aux
 
 #endif

--- a/include/boost/di/aux_/utility.hpp
+++ b/include/boost/di/aux_/utility.hpp
@@ -154,6 +154,6 @@ struct make_index_sequence_impl<10> : index_sequence<0, 1, 2, 3, 4, 5, 6, 7, 8, 
 template <int N>
 using make_index_sequence = typename make_index_sequence_impl<N>::type;
 
-}  // aux
+}  // namespace aux
 
 #endif

--- a/include/boost/di/bindings.hpp
+++ b/include/boost/di/bindings.hpp
@@ -35,7 +35,7 @@ struct bind<int, TScope, Ts...> {
   using type = core::dependency<TScope, concepts::any_of<Ts...>>;
 };
 
-}  // detail
+}  // namespace detail
 
 template <class... Ts>
 #if defined(__cpp_variable_templates)  // __pph__

--- a/include/boost/di/concepts/boundable.hpp
+++ b/include/boost/di/concepts/boundable.hpp
@@ -143,10 +143,11 @@ using boundable_impl__ = aux::conditional_t<
     aux::conditional_t<is_abstract<aux::is_complete<T>::value, T>::value, typename type_<T>::is_abstract, aux::true_type>,
     typename type_<T>::template is_not_related_to<I>>;
 
-template <class I, class T>                                                                   // expected -> given
-auto boundable_impl(I&&, T &&) -> aux::conditional_t<aux::is_same<T, aux::decay_t<T>>::value  // I is already verified
-                                                     ,
-                                                     boundable_impl__<I, T>, typename type_<T>::has_disallowed_qualifiers>;
+template <class I, class T>  // expected -> given
+auto boundable_impl(I&&, T &&)
+    -> aux::conditional_t<aux::is_same<T, aux::decay_t<T>>::value || !aux::is_complete<I>::value  // I is already verified
+                          ,
+                          boundable_impl__<I, T>, typename type_<T>::has_disallowed_qualifiers>;
 
 template <class I, class T>  // expected -> given
 auto boundable_impl(I&&, T&&, aux::valid<> &&)

--- a/include/boost/di/concepts/callable.hpp
+++ b/include/boost/di/concepts/callable.hpp
@@ -68,6 +68,6 @@ struct is_callable<void> {  // auto
 template <class... Ts>
 using callable = typename is_callable<Ts...>::type;
 
-}  // concepts
+}  // namespace concepts
 
 #endif

--- a/include/boost/di/concepts/configurable.hpp
+++ b/include/boost/di/concepts/configurable.hpp
@@ -73,6 +73,6 @@ struct configurable__ {
 template <class T>
 using configurable = typename configurable__<T>::type;
 
-}  // concepts
+}  // namespace concepts
 
 #endif

--- a/include/boost/di/concepts/creatable.hpp
+++ b/include/boost/di/concepts/creatable.hpp
@@ -179,6 +179,6 @@ T creatable_error() {
   return creatable_error_impl<TInitialization, TName, T, aux::type_list<TArgs...>>{};
 }
 
-}  // concepts
+}  // namespace concepts
 
 #endif

--- a/include/boost/di/concepts/providable.hpp
+++ b/include/boost/di/concepts/providable.hpp
@@ -42,6 +42,6 @@ struct providable__ {
 template <class T>
 using providable = typename providable__<T>::type;
 
-}  // concepts
+}  // namespace concepts
 
 #endif

--- a/include/boost/di/concepts/scopable.hpp
+++ b/include/boost/di/concepts/scopable.hpp
@@ -84,6 +84,6 @@ struct scopable__ {
 template <class T>
 using scopable = typename scopable__<T>::type;
 
-}  // concepts
+}  // namespace concepts
 
 #endif

--- a/include/boost/di/core/any_type.hpp
+++ b/include/boost/di/core/any_type.hpp
@@ -209,7 +209,7 @@ struct any_type_1st_ref {
   const TInjector& injector_;
 };
 
-}  // successful
+}  // namespace successful
 
 template <class>
 struct any_type_fwd {
@@ -265,6 +265,6 @@ struct any_type_1st_ref_fwd {
   operator const T&() const;
 };
 
-}  // core
+}  // namespace core
 
 #endif

--- a/include/boost/di/core/array.hpp
+++ b/include/boost/di/core/array.hpp
@@ -41,12 +41,12 @@ struct array<T()> : T {
   using boost_di_inject__ = aux::type_list<>;
 };
 
-}  // core
+}  // namespace core
 
 namespace type_traits {
 template <class _, class T, class... Ts>
 struct ctor_traits__<core::array<_, Ts...>, T, aux::false_type>
     : type_traits::ctor_traits__<core::array<aux::remove_smart_ptr_t<aux::remove_qualifiers_t<T>>(), Ts...>> {};
-}  // type_traits
+}  // namespace type_traits
 
 #endif

--- a/include/boost/di/core/binder.hpp
+++ b/include/boost/di/core/binder.hpp
@@ -92,6 +92,6 @@ struct binder {
   using resolve_template_t = typename resolve_template_impl<TDeps, aux::remove_qualifiers_t<T>>::type;
 };
 
-}  // core
+}  // namespace core
 
 #endif

--- a/include/boost/di/core/bindings.hpp
+++ b/include/boost/di/core/bindings.hpp
@@ -38,6 +38,6 @@ template <class... Ts>
 using bindings_t = aux::join_t<typename bindings_impl<Ts>::type...>;
 #endif  // __pph__
 
-}  // core
+}  // namespace core
 
 #endif

--- a/include/boost/di/core/dependency.hpp
+++ b/include/boost/di/core/dependency.hpp
@@ -184,13 +184,13 @@ class dependency
 #endif  // __pph__
 
  protected:
-  using scope_t::is_referable;
   using scope_t::create;
+  using scope_t::is_referable;
   using scope_t::try_create;
   template <class, class>
   static void try_create(...);
 };
 
-}  // core
+}  // namespace core
 
 #endif

--- a/include/boost/di/core/policy.hpp
+++ b/include/boost/di/core/policy.hpp
@@ -68,6 +68,6 @@ class policy {
   }
 };
 
-}  // core
+}  // namespace core
 
 #endif

--- a/include/boost/di/core/pool.hpp
+++ b/include/boost/di/core/pool.hpp
@@ -35,6 +35,6 @@ struct pool<aux::type_list<TArgs...>> : TArgs... {
   }
 };
 
-}  // core
+}  // namespace core
 
 #endif

--- a/include/boost/di/core/provider.hpp
+++ b/include/boost/di/core/provider.hpp
@@ -107,7 +107,7 @@ struct provider<aux::pair<T, aux::pair<TInitialization, TList<TCtor...>>>, TInje
 
   const TInjector* injector_;
 };
-}  // successful
-}  // core
+}  // namespace successful
+}  // namespace core
 
 #endif

--- a/include/boost/di/core/wrapper.hpp
+++ b/include/boost/di/core/wrapper.hpp
@@ -21,7 +21,7 @@ struct wrapper {
   TWrapper wrapper_;
 };
 
-}  // successful
+}  // namespace successful
 
 template <class T, class TWrapper, class = int>
 struct wrapper_impl {
@@ -41,6 +41,6 @@ struct wrapper_impl<T, TWrapper<TScope, T_, Ts...>,
 template <class T, class TWrapper>
 using wrapper = wrapper_impl<T, TWrapper>;
 
-}  // core
+}  // namespace core
 
 #endif

--- a/include/boost/di/fwd.hpp
+++ b/include/boost/di/fwd.hpp
@@ -37,16 +37,16 @@ struct injector_base {};
 
 template <class T>
 struct dependency__ : T {
-  using T::try_create;
-  using T::is_referable;
   using T::create;
+  using T::is_referable;
+  using T::try_create;
 };
 
 template <class T>
 struct injector__ : T {
+  using T::cfg;
   using T::create_impl;
   using T::create_successful_impl;
-  using T::cfg;
 
 #if defined(__MSVC__)  // __pph__
   template <class... Ts>
@@ -54,8 +54,8 @@ struct injector__ : T {
   template <class... Ts>
   using try_create = typename T::template try_create<Ts...>;
 #else   // __pph__
-  using T::try_create;
   using T::is_creatable;
+  using T::try_create;
 #endif  // __pph__
 };
 
@@ -66,13 +66,13 @@ struct deduced {};
 
 template <class, class TExpected = deduced, class = TExpected, class = no_name, class = void>
 class dependency;
-}  // core
+}  // namespace core
 
 namespace scopes {
 class deduce;
 class instance;
 class singleton;
 class unique;
-}  // scopes
+}  // namespace scopes
 
 #endif

--- a/include/boost/di/fwd_ext.hpp
+++ b/include/boost/di/fwd_ext.hpp
@@ -99,7 +99,7 @@ NAMESPACE_STD_END
 namespace boost {
 template <class>
 class shared_ptr;
-}  // boost
+}  // namespace boost
 #endif                           // __pph__
 
 #undef NAMESPACE_STD_BEGIN  // __pph__

--- a/include/boost/di/inject.hpp
+++ b/include/boost/di/inject.hpp
@@ -45,7 +45,7 @@ struct combine<aux::type_list<T1...>, aux::type_list<T2...>> {
 template <class T1, class T2>
 using combine_t = typename combine<T1, T2>::type;
 
-}  // detail
+}  // namespace detail
 
 template <class... Ts>
 using inject = aux::type_list<Ts...>;

--- a/include/boost/di/injector.hpp
+++ b/include/boost/di/injector.hpp
@@ -56,7 +56,7 @@ create<T> (
   }
 };
 
-}  // detail
+}  // namespace detail
 
 template <class T, class... Ts>
 using injector = detail::injector<

--- a/include/boost/di/make_injector.hpp
+++ b/include/boost/di/make_injector.hpp
@@ -24,7 +24,7 @@ static auto make_injector = [](auto injector) {
   };
   return i{static_cast<injector_t&&>(injector)};
 };
-}  // detail
+}  // namespace detail
 #define __BOOST_DI_MAKE_INJECTOR(...) detail::make_injector(__VA_ARGS__)  // __pph__
 #endif                                                                    // __pph__
 

--- a/include/boost/di/policies/constructible.hpp
+++ b/include/boost/di/policies/constructible.hpp
@@ -71,7 +71,7 @@ struct or_ : detail::type_op {
                                                       aux::bool_list<aux::never<Ts>::value...>>::value> {};
 };
 
-}  // detail
+}  // namespace detail
 
 template <class T>
 struct type {
@@ -132,7 +132,7 @@ inline auto operator!(const T&) {
   return detail::not_<T>{};
 }
 
-}  // operators
+}  // namespace operators
 
 template <bool, class T>
 struct constructible_impl {
@@ -172,6 +172,6 @@ inline auto constructible(const T& = {}) {
   return constructible_impl<IncludeRoot, detail::or_<T>>{};
 }
 
-}  // policies
+}  // namespace policies
 
 #endif

--- a/include/boost/di/providers/stack_over_heap.hpp
+++ b/include/boost/di/providers/stack_over_heap.hpp
@@ -41,6 +41,6 @@ class stack_over_heap {
   }
 };
 
-}  // providers
+}  // namespace providers
 
 #endif

--- a/include/boost/di/scopes/deduce.hpp
+++ b/include/boost/di/scopes/deduce.hpp
@@ -34,7 +34,7 @@ class deduce {
   };
 };
 
-}  // scopes
+}  // namespace scopes
 
 static constexpr __BOOST_DI_UNUSED scopes::deduce deduce{};
 

--- a/include/boost/di/scopes/instance.hpp
+++ b/include/boost/di/scopes/instance.hpp
@@ -45,7 +45,7 @@ struct is_expr
     : aux::integral_constant<
           bool, aux::is_invocable<TGiven, typename TProvider::injector, Ts...>::value && !has_result_type<TGiven>::value> {};
 
-}  // detail
+}  // namespace detail
 
 template <class T>
 struct wrapper {
@@ -291,6 +291,6 @@ class instance {
   };
 };
 
-}  // scopes
+}  // namespace scopes
 
 #endif

--- a/include/boost/di/scopes/singleton.hpp
+++ b/include/boost/di/scopes/singleton.hpp
@@ -63,7 +63,7 @@ class singleton {
   };
 };
 
-}  // scopes
+}  // namespace scopes
 
 static constexpr __BOOST_DI_UNUSED scopes::singleton singleton{};
 

--- a/include/boost/di/scopes/unique.hpp
+++ b/include/boost/di/scopes/unique.hpp
@@ -35,7 +35,7 @@ class unique {
   };
 };
 
-}  // scopes
+}  // namespace scopes
 
 static constexpr __BOOST_DI_UNUSED scopes::unique unique{};
 

--- a/include/boost/di/type_traits/ctor_traits.hpp
+++ b/include/boost/di/type_traits/ctor_traits.hpp
@@ -85,7 +85,7 @@ struct ctor_traits_impl<T, _, aux::true_type>
 template <class T, class _>
 struct ctor_traits_impl<T, _, aux::false_type> : aux::pair<T, typename ctor_traits<T>::type> {};
 
-}  // type_traits
+}  // namespace type_traits
 
 template <class T, class>
 struct ctor_traits : type_traits::ctor<T, type_traits::ctor_impl_t<aux::is_constructible, T>> {};

--- a/include/boost/di/type_traits/memory_traits.hpp
+++ b/include/boost/di/type_traits/memory_traits.hpp
@@ -55,6 +55,6 @@ struct memory_traits<T, __BOOST_DI_REQUIRES(aux::is_polymorphic<T>::value)> {
   using type = heap;
 };
 
-}  // type_traits
+}  // namespace type_traits
 
 #endif

--- a/include/boost/di/type_traits/named_traits.hpp
+++ b/include/boost/di/type_traits/named_traits.hpp
@@ -51,6 +51,6 @@ struct named_decay<named<TName, T>> {
 template <class T>
 using named_decay_t = typename named_decay<T>::type;
 
-}  // type_traits
+}  // namespace type_traits
 
 #endif

--- a/include/boost/di/type_traits/rebind_traits.hpp
+++ b/include/boost/di/type_traits/rebind_traits.hpp
@@ -64,6 +64,6 @@ struct rebind_traits<boost::shared_ptr<T>, named<TName, _>> {
 template <class T, class U>
 using rebind_traits_t = typename rebind_traits<T, U>::type;
 
-}  // type_traits
+}  // namespace type_traits
 
 #endif

--- a/include/boost/di/type_traits/scope_traits.hpp
+++ b/include/boost/di/type_traits/scope_traits.hpp
@@ -37,6 +37,6 @@ struct scope_traits<std::weak_ptr<T>> {
   using type = scopes::singleton;
 };
 
-}  // type_traits
+}  // namespace type_traits
 
 #endif

--- a/include/boost/di/wrappers/shared.hpp
+++ b/include/boost/di/wrappers/shared.hpp
@@ -78,6 +78,6 @@ struct shared<TScope, T&> {
   T* object = nullptr;
 };
 
-}  // wrappers
+}  // namespace wrappers
 
 #endif

--- a/include/boost/di/wrappers/unique.hpp
+++ b/include/boost/di/wrappers/unique.hpp
@@ -72,6 +72,6 @@ struct unique<TScope, T*> {
   T* object = nullptr;
 };
 
-}  // wrappers
+}  // namespace wrappers
 
 #endif

--- a/test/ft/di_bind.cpp
+++ b/test/ft/di_bind.cpp
@@ -26,7 +26,7 @@ template <class T>
 struct is_related<true, Concept, T> {
   static constexpr auto value = true;
 };
-}  // concepts
+}  // namespace concepts
 
 BOOST_DI_NAMESPACE_END
 
@@ -1143,6 +1143,23 @@ test bind_template_to_type_templates_type = [] {
   static_expect(std::is_same<classA<classB>, std::decay_t<decltype(object.t)>>::value);
   static_expect(std::is_same<classB, std::decay_t<typename decltype(object.t)::type>>::value);
   expect(42 == object.t.i);
+};
+
+template <typename T = A>
+struct appc {
+  explicit appc(T &t) : t(t) { static_expect(std::is_same<T, std::vector<std::string>>::value); }
+  T &t;
+};
+
+test bind_template_to_container_type = [] {
+  using T = std::vector<std::string>;
+  T t{"str1", "str2"};
+  const auto injector = di::make_injector(di::bind<A>().to<T>(), di::bind<>().to(t));
+  auto object = injector.create<appc>();
+
+  expect(2 == object.t.size());
+  expect("str1" == object.t[0]);
+  expect("str2" == object.t[1]);
 };
 
 #if !defined(__MSVC__)

--- a/test/ft/di_errors.cpp
+++ b/test/ft/di_errors.cpp
@@ -99,7 +99,7 @@ auto compail_fail(int id, const std::string& defines, const std::vector<std::str
     expect(false);
   }
 }
-}
+}  // namespace
 
 #define expect_compile_fail(defines, error, ...) compail_fail(__LINE__, defines, error, #__VA_ARGS__)
 

--- a/test/ft/di_inject.cpp
+++ b/test/ft/di_inject.cpp
@@ -80,8 +80,8 @@ template <>
 struct ctor_traits<c_no_limits> {
   using boost_di_inject__ = di::inject<int, int, int, int, int, int, int, int, int, int, int>;
 };
-}
-}  // boost::di
+}  // namespace di
+}  // namespace boost
 
 test inject_traits_no_limits_via_ctor_traits = [] {
   auto injector = di::make_injector();

--- a/test/ft/di_injector_except.cpp
+++ b/test/ft/di_injector_except.cpp
@@ -27,7 +27,6 @@ test should_throw_when_ctor_throws = [] {
 struct empty {};
 
 test should_throw_when_lambda_with_2_args_throws = [] {
-
   const auto injector = di::make_injector(di::bind<empty>().to([](const auto&, const auto&) {
     throw 0;
     return empty{};
@@ -43,7 +42,6 @@ test should_throw_when_lambda_with_2_args_throws = [] {
 };
 
 test should_throw_when_lambda_with_1_arg_throws = [] {
-
   const auto injector = di::make_injector(di::bind<empty>().to([](const auto&) {
     throw 0;
     return empty{};
@@ -59,7 +57,6 @@ test should_throw_when_lambda_with_1_arg_throws = [] {
 };
 
 test should_throw_when_lambda_with_no_args_throws = [] {
-
   const auto injector = di::make_injector(di::bind<empty>().to([]() {
     throw 0;
     return empty{};
@@ -83,7 +80,6 @@ struct except_factory {
 };
 
 test should_throw_when_factory_with_1_arg_throws = [] {
-
   const auto injector = di::make_injector(di::bind<empty>().to(except_factory{}));
 
   auto cought = false;

--- a/test/pt/di_compile_time.cpp
+++ b/test/pt/di_compile_time.cpp
@@ -295,7 +295,7 @@ auto benchmark = [](const std::string& complexity, bool interfaces = false, int 
 };
 
 auto is_benchmark(const std::string& name) { return std::getenv("BENCHMARK") && std::string{std::getenv("BENCHMARK")} == name; }
-}
+}  // namespace
 
 test small_complexity = [] {
   if (is_benchmark("ON")) {

--- a/test/ut/aux_/type_traits.cpp
+++ b/test/ut/aux_/type_traits.cpp
@@ -301,4 +301,4 @@ test is_empty_expr_types = [] {
   static_expect(!is_empty_expr<decltype(capture)>::value);
 };
 
-}  // aux
+}  // namespace aux

--- a/test/ut/aux_/utility.cpp
+++ b/test/ut/aux_/utility.cpp
@@ -31,4 +31,4 @@ test join_types = [] {
   static_expect(std::is_same<type_list<float, double>, join_t<type_list<>, type_list<float, double>>>::value);
 };
 
-}  // aux
+}  // namespace aux

--- a/test/ut/concepts/boundable.cpp
+++ b/test/ut/concepts/boundable.cpp
@@ -70,4 +70,4 @@ test bind_injector = [] {
   static_expect(std::is_same<type_<double>::is_bound_more_than_once, boundable<aux::type<int, double, float, double>>>::value);
 };
 
-}  // concepts
+}  // namespace concepts

--- a/test/ut/concepts/callable.cpp
+++ b/test/ut/concepts/callable.cpp
@@ -48,4 +48,4 @@ test is_concept_callable = [] {
   static_expect(!callable<callable_type_extended>::value);
 };
 
-}  // concepts
+}  // namespace concepts

--- a/test/ut/concepts/configurable.cpp
+++ b/test/ut/concepts/configurable.cpp
@@ -87,4 +87,4 @@ class config_okay_type {
 
 test okay_type = [] { static_expect(configurable<config_okay_type>::value); };
 
-}  // concepts
+}  // namespace concepts

--- a/test/ut/concepts/creatable.cpp
+++ b/test/ut/concepts/creatable.cpp
@@ -35,4 +35,4 @@ test is_creatable = [] {
 #endif
 };
 
-}  // concepts
+}  // namespace concepts

--- a/test/ut/concepts/providable.cpp
+++ b/test/ut/concepts/providable.cpp
@@ -68,4 +68,4 @@ test wrong_get = [] {
 
 test providable_providers = [] { static_expect(providable<providers::stack_over_heap>::value); };
 
-}  // concepts
+}  // namespace concepts

--- a/test/ut/concepts/scopable.cpp
+++ b/test/ut/concepts/scopable.cpp
@@ -115,4 +115,4 @@ test scopable_scopes = [] {
   static_expect(scopable<scopes::unique>::value);
 };
 
-}  // concepts
+}  // namespace concepts

--- a/test/ut/core/any_type.cpp
+++ b/test/ut/core/any_type.cpp
@@ -49,4 +49,4 @@ test any_type_ref_create = [] {
   expect(0 == static_cast<int>(any_type_ref<void, fake_injector<>>{injector}));
 };
 
-}  // core
+}  // namespace core

--- a/test/ut/core/array.cpp
+++ b/test/ut/core/array.cpp
@@ -37,4 +37,4 @@ test array_ctor_named = [] {
   expect(*a[1] == 87);
 };
 
-}  // core
+}  // namespace core

--- a/test/ut/core/binder.cpp
+++ b/test/ut/core/binder.cpp
@@ -81,4 +81,4 @@ test resolve_types_found_priority_order = [] {
   expect(std::is_same<result, dependency<scopes::unique, int, int, no_name, override>>{});
 };
 
-}  // core
+}  // namespace core

--- a/test/ut/core/bindings.cpp
+++ b/test/ut/core/bindings.cpp
@@ -18,4 +18,4 @@ test bindings_deps = [] {
                              bindings_t<fake_dependency<int>, fake_dependency<double>>>::value);
 };
 
-}  // core
+}  // namespace core

--- a/test/ut/core/dependency.cpp
+++ b/test/ut/core/dependency.cpp
@@ -66,4 +66,4 @@ test to = [] {
   expect(std::is_same<int, typename dep2::given>::value);
 };
 
-}  // core
+}  // namespace core

--- a/test/ut/core/injector.cpp
+++ b/test/ut/core/injector.cpp
@@ -95,4 +95,4 @@ test create = [] {
   expect(0 == injector_.create<int>());
 };
 
-}  // core
+}  // namespace core

--- a/test/ut/core/policy.cpp
+++ b/test/ut/core/policy.cpp
@@ -71,4 +71,4 @@ test ignore_internal_types = [] {
   expect(2 == fake_policy_other::calls());
 };
 
-}  // core
+}  // namespace core

--- a/test/ut/core/pool.cpp
+++ b/test/ut/core/pool.cpp
@@ -194,4 +194,4 @@ test pool_flatten = [] {
   expect(0 == static_cast<const trivial_ctor&>(p2).i);
 };
 
-}  // core
+}  // namespace core

--- a/test/ut/core/provider.cpp
+++ b/test/ut/core/provider.cpp
@@ -32,4 +32,4 @@ test get_heap = [] {
   expect(ptr.get());
 };
 
-}  // core
+}  // namespace core

--- a/test/ut/core/wrapper.cpp
+++ b/test/ut/core/wrapper.cpp
@@ -12,4 +12,4 @@ namespace core {
 
 test successful_wrapper = [] { expect(0 == static_cast<int>(wrapper<int, fake_wrapper>{})); };
 
-}  // core
+}  // namespace core

--- a/test/ut/policies/constructible.cpp
+++ b/test/ut/policies/constructible.cpp
@@ -145,4 +145,4 @@ test complex_opeartors = [] {
   expect(test(fake_policy<double, aux::none_type, aux::none_type, true>{}));
 };
 
-}  // policies
+}  // namespace policies

--- a/test/ut/providers/stack_over_heap.cpp
+++ b/test/ut/providers/stack_over_heap.cpp
@@ -49,4 +49,4 @@ test get_with_args = [] {
 #endif
 };
 
-}  // providers
+}  // namespace providers

--- a/test/ut/scopes/deduce.cpp
+++ b/test/ut/scopes/deduce.cpp
@@ -32,4 +32,4 @@ test create_from_scope = [] {
   expect(1 == fake_scope<>::calls());
 };
 
-}  // scopes
+}  // namespace scopes

--- a/test/ut/scopes/instance.cpp
+++ b/test/ut/scopes/instance.cpp
@@ -130,4 +130,4 @@ test exposed_many = [] {
   expect(0.0 == static_cast<double>(instance.create<double, name>(fake_provider<int>{})));
 };
 
-}  // scopes
+}  // namespace scopes

--- a/test/ut/scopes/singleton.cpp
+++ b/test/ut/scopes/singleton.cpp
@@ -34,4 +34,4 @@ test create_singleton_from_ptr_to_const_ptr = [] {
   expect(&object1 == &object2);
 };
 
-}  // scopes
+}  // namespace scopes

--- a/test/ut/scopes/unique.cpp
+++ b/test/ut/scopes/unique.cpp
@@ -24,4 +24,4 @@ test create_shared_but_unique = [] {
   expect(object1 != object2);
 };
 
-}  // scopes
+}  // namespace scopes

--- a/test/ut/type_traits/ctor_traits.cpp
+++ b/test/ut/type_traits/ctor_traits.cpp
@@ -175,4 +175,4 @@ test special_std_types = [] {
   test_ctor_traits<std::initializer_list<int>, direct>();
 };
 
-}  // type_traits
+}  // namespace type_traits

--- a/test/ut/type_traits/memory_traits.cpp
+++ b/test/ut/type_traits/memory_traits.cpp
@@ -47,4 +47,4 @@ test traits = [] {
 #endif
 };
 
-}  // type_traits
+}  // namespace type_traits

--- a/test/ut/type_traits/named_traits.cpp
+++ b/test/ut/type_traits/named_traits.cpp
@@ -33,4 +33,4 @@ test named_decay_traits = [] {
   static_expect(std::is_same<named<no_name, int>, named_decay_t<named<no_name, int*>>>::value);
 };
 
-}  // type_traits
+}  // namespace type_traits

--- a/test/ut/type_traits/rebind_traits.cpp
+++ b/test/ut/type_traits/rebind_traits.cpp
@@ -27,4 +27,4 @@ test traits = [] {
   static_expect(std::is_same<named<void, std::weak_ptr<int>>, rebind_traits_t<std::weak_ptr<int>, named<void>>>{});
 };
 
-}  // type_traits
+}  // namespace type_traits

--- a/test/ut/type_traits/scope_traits.cpp
+++ b/test/ut/type_traits/scope_traits.cpp
@@ -37,4 +37,4 @@ test traits = [] {
   static_expect(std::is_same<scopes::unique, scope_traits_t<const int&&>>{});
 };
 
-}  // type_traits
+}  // namespace type_traits

--- a/test/ut/wrappers/shared.cpp
+++ b/test/ut/wrappers/shared.cpp
@@ -41,4 +41,4 @@ test to_weak_ptr = [] {
   expect(!object.lock());
 };
 
-}  // wrappers
+}  // namespace wrappers

--- a/test/ut/wrappers/unique.cpp
+++ b/test/ut/wrappers/unique.cpp
@@ -76,4 +76,4 @@ test to_unique_ptr_from_unique_ptr = [] {
   expect(i == *object);
 };
 
-}  // wrappers
+}  // namespace wrappers


### PR DESCRIPTION
Problem:
- When binding `std::vector` to a templated type there is compilation error: "T has disallowed qualifiers".

Solution:
- Don't check for disallowed qualifiers when expected type is incomplete.