### PR TITLE
RFC: impl side singleton and weak_ptr for singleton storage

### DIFF
--- a/include/boost/di/scopes/singleton.hpp
+++ b/include/boost/di/scopes/singleton.hpp
@@ -15,6 +15,21 @@
 namespace scopes {
 
 class singleton {
+  template<typename T>
+  static std::shared_ptr<T>& get_storage_impl() {
+    static std::shared_ptr<T> object;
+    return object;
+  }
+  template<typename T>
+  struct stack_storage {
+    bool initialized{false};
+    alignas(alignof(T)) char memory[sizeof(T)];
+  };
+  template<typename T>
+  static stack_storage<T>& get_stack_storage() {
+    static stack_storage<T> object;
+    return object;
+  }
  public:
   template <class, class T, class = decltype(aux::has_shared_ptr__(aux::declval<T>()))>
   class scope {
@@ -34,8 +49,12 @@ class singleton {
    private:
     template <class TProvider>
     wrappers::shared<singleton, T&> create_impl(const TProvider& provider) {
-      static auto object(provider.get(type_traits::stack{}));
-      return wrappers::shared<singleton, T&>(object);
+      auto& storage = get_stack_storage<T>();
+      if (!storage.initialized) {
+        new (storage.memory) T(provider.get(type_traits::stack{}));
+        storage.initialized = true;
+      }
+      return wrappers::shared<singleton, T&>(reinterpret_cast<T*>(storage.memory));
     }
   };
 
@@ -57,8 +76,10 @@ class singleton {
    private:
     template <class T_, class TProvider>
     auto create_impl(const TProvider& provider) {
-      static std::shared_ptr<T_> object{provider.get()};
-      return wrappers::shared<singleton, T_, std::shared_ptr<T_>&>{object};
+      auto& shared_storage = get_storage_impl<T_>();
+      if (!shared_storage)
+        shared_storage = std::shared_ptr<T_>{provider.get()};
+      return wrappers::shared<singleton, T_, std::shared_ptr<T_>&>{shared_storage};
     }
   };
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,5 +77,4 @@ endif()
 test(ft/di_injector_except)
 
 test(pt/di_compile_time)
-set(CMAKE_BUILD_TYPE Release)
 test(pt/di_run_time)


### PR DESCRIPTION
Hi this is more a rfc than proper pull request. I did not implement weak_ptr suggestion..

I stumbled over the fact that the singleton instance is depending on the requested interface. 
Consider this simplified use case.
```
    struct A  : iface {};

     boost::di::bind<iface>().template to<A>;

     auto a  = injector.create<std::shared_ptr<A>>();
     auto b = injector.create<std::shared_ptr<iface>>();
```
then a and b will end up being different singletons. I assumed that behavior to be a bug - so I changed the way singleton scope creates and handles its memory. While doing so I discovered that there is another bind syntax, which allows multiple interfaces to be provided by an implementation. So I could reformulate the above like this:
```
     boost::di::bind<A,iface>().template to<A>;
```

I do not see the reason for the default use case though.

Additionally I think it would make more sense to only store a weak_ptr and hand out shared_ptrs. But that makes the "stack" singleton behave different than the one based on shared pointers.


Reviewers:
@gjasny @krzysztof-jusiak 