### PR TITLE
Replace copy of unique temporarry object with move

### DIFF
--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -1321,7 +1321,7 @@ struct unique<TScope, T*> {
       aux::owner<T*> ptr;
       ~scoped_ptr() noexcept { delete ptr; }
     };
-    return *scoped_ptr{object}.ptr;
+    return static_cast<T&&>(*scoped_ptr{object}.ptr);
   }
   template <class I, __BOOST_DI_REQUIRES(aux::is_convertible<T*, I*>::value) = 0>
   inline operator aux::owner<I*>() const noexcept {

--- a/include/boost/di/wrappers/unique.hpp
+++ b/include/boost/di/wrappers/unique.hpp
@@ -41,7 +41,7 @@ struct unique<TScope, T*> {
       aux::owner<T*> ptr;
       ~scoped_ptr() noexcept { delete ptr; }
     };
-    return *scoped_ptr{object}.ptr;
+    return static_cast<T&&>(*scoped_ptr{object}.ptr);
   }
 
   template <class I, __BOOST_DI_REQUIRES(aux::is_convertible<T*, I*>::value) = 0>

--- a/test/ut/wrappers/unique.cpp
+++ b/test/ut/wrappers/unique.cpp
@@ -15,10 +15,17 @@ namespace wrappers {
 
 struct interface {
   virtual ~interface() noexcept = default;
-  virtual void dummy() = 0;
+  virtual int get_f() = 0;
 };
-struct implementation : public interface {
-  void dummy() override{};
+struct implementation : interface {
+  implementation() = default;
+  explicit implementation(int f) : f(f) {}
+  implementation(implementation&& other) noexcept = default;
+  implementation(implementation&) = delete;
+  int get_f() override { return f; }
+
+ private:
+  int f = 0;
 };
 
 constexpr auto i = 42;
@@ -49,7 +56,12 @@ test to_const_ptr = [] {
   expect(i == *object);
 };
 
-test to_copy = [] {
+test to_move_no_copy_ctor = [] {
+  auto u = unique<fake_scope<>, implementation*>{new implementation{i}};
+  expect(static_cast<implementation>(u).get_f() == i);
+};
+
+test to_move = [] {
   auto object = static_cast<int>(unique<fake_scope<>, int*>{new int{i}});
   expect(i == object);
 };


### PR DESCRIPTION
Problem:
- Unique wrapper makes copy of object before destroying temporary object

Solution:
- Return moved object instead of copied

Issue: #362

Reviewers:
@krzysztof-jusiak 