### PR TITLE
Fix a case when empty injector is passed to `make_extensible`

### DIFF
--- a/extension/include/boost/di/extension/injections/extensible_injector.hpp
+++ b/extension/include/boost/di/extension/injections/extensible_injector.hpp
@@ -55,6 +55,7 @@ auto make_extensible_impl(const aux::type<TDependency>&, TInjector& injector) {
 
 template <class... TDeps, class TInjector>
 auto make_extensible(const aux::type_list<TDeps...>&, TInjector& injector) {
+  (void)injector;
   return make_injector(make_extensible_impl(aux::type<TDeps>{}, injector)...);
 }
 

--- a/extension/test/injections/extensible_injector.cpp
+++ b/extension/test/injections/extensible_injector.cpp
@@ -90,4 +90,12 @@ int main() {
   }
   //<<after death of extended dependency original dependency is still alive>>
   assert(im3_orig == orig_injector.create<std::shared_ptr<implementation3>>());
+
+  {
+    //<<make_extensible can be called with empty injector>>
+    auto empty_injector = di::make_injector();
+    auto empty_extended_injector = di::make_injector(di::extension::make_extensible(empty_injector));
+    auto instance = empty_extended_injector.create<implementation1>();
+    assert(1 == instance.num());
+  }
 }


### PR DESCRIPTION
Problem:
- If injector is empty `make_extensible` gets a warning that injector is unreferenced

Solution:
- Explicitly reference injector argument

Issue: #

Reviewers:
@krzysztof-jusiak 