### PR TITLE
:white_check_mark: [extension] Support for installing modules in `run…

### DIFF
--- a/extension/test/providers/runtime_provider.cpp
+++ b/extension/test/providers/runtime_provider.cpp
@@ -7,6 +7,7 @@
 #include "boost/di/extension/providers/runtime_provider.hpp"
 
 #include <cassert>
+#include <string>
 
 namespace di = boost::di;
 
@@ -20,23 +21,57 @@ struct i2 {
   virtual int bar() const = 0;
 };
 
+struct i3 {
+  virtual ~i3() noexcept = default;
+  virtual int f() const = 0;
+};
+
+struct i4 {
+  virtual ~i4() noexcept = default;
+  virtual int foo() const = 0;
+};
+
+struct impl3 : i3 {
+  explicit impl3(const int& i) { assert(i == 87); }
+  int f() const override { return 1234; }
+};
+
 struct impl2 : i2 {
+  explicit impl2(i3& i, std::string str) {
+    assert(i.f() == 1234);
+    assert(str == "text");
+  }
   int bar() const override { return 99; }
 };
 
 struct impl1 : i1 {
-  impl1(std::unique_ptr<i2> sp2) { assert(sp2->bar() == 99); }
-
+  explicit impl1(std::unique_ptr<i2> sp2) { assert(sp2->bar() == 99); }
   int foo() const override { return 42; }
 };
 
+struct impl4 : i4 {
+  int foo() const override { return 100; }
+};
+
+class module_example {
+ public:
+  explicit module_example(std::shared_ptr<i4> sp) : sp{sp} {}
+  auto get() const { return sp->foo() * 2; }
+
+ private:
+  std::shared_ptr<i4> sp{};
+};
+
 struct example {
-  example(std::shared_ptr<i1> sp, int i) {
+  example(std::shared_ptr<i1> sp, int i, module_example& me) {
     assert(dynamic_cast<impl1*>(sp.get()));
     assert(sp->foo() == 42);
     assert(i == 87);
+    assert(me.get() == 2 * 100);
   }
 };
+
+auto module = [] { return di::make_injector(di::bind<i4>().to<impl4>()); };
 
 int main() {
   // clang-format off
@@ -53,6 +88,16 @@ int main() {
 
   /*<<more bindings>>*/
   injector.install(di::bind<int>().to(87));
+
+  /*<<injector bindings>>*/
+  auto component = di::make_injector(
+    di::bind<i3>().to<impl3>(),
+    di::bind<std::string>().to("text")
+  );
+  injector.install(component);
+
+  /*<<module bindings>>*/
+  injector.install(module());
 
   /*<<create example>>*/
   injector.create<example>();

--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -2448,7 +2448,7 @@ inline auto build(TInjector&& injector) noexcept {
 }
 #endif
 template <class TConfig, class TPolicies = pool<>, class... TDeps>
-class injector : injector_base, public pool<bindings_t<TDeps...>> {
+class injector : public injector_base, public pool<bindings_t<TDeps...>> {
   using pool_t = pool<bindings_t<TDeps...>>;
 
  protected:
@@ -2652,7 +2652,7 @@ class injector : injector_base, public pool<bindings_t<TDeps...>> {
   config config_;
 };
 template <class TConfig, class... TDeps>
-class injector<TConfig, pool<>, TDeps...> : injector_base, public pool<bindings_t<TDeps...>> {
+class injector<TConfig, pool<>, TDeps...> : public injector_base, public pool<bindings_t<TDeps...>> {
   using pool_t = pool<bindings_t<TDeps...>>;
 
  protected:

--- a/include/boost/di/core/injector.hpp
+++ b/include/boost/di/core/injector.hpp
@@ -71,7 +71,7 @@ inline auto build(TInjector&& injector) noexcept {
 
 template <class TConfig __BOOST_DI_CORE_INJECTOR_POLICY(, class TPolicies = pool<>)(), class... TDeps>
 class injector __BOOST_DI_CORE_INJECTOR_POLICY()(<TConfig, pool<>, TDeps...>)
-    : injector_base, public pool<bindings_t<TDeps...>> {
+    : public injector_base, public pool<bindings_t<TDeps...>> {
   using pool_t = pool<bindings_t<TDeps...>>;
 
  protected:


### PR DESCRIPTION
…time_provider`

Problem:
- Modules can't be installed with the `install` call.

Solution:
- Add support for installing modules with the `install` call.