### PR TITLE
:arrow_up: :wrench: [travis] Add newest gcc/clang/xcode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,18 @@ matrix:
 
   - os: linux
     dist: trusty
-    env: BS=cmake CXX=clang++-5.0 LIBCXX=ON
-    addons: { apt: { packages: ["clang-5.0", "libstdc++-6-dev", "gdb"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-5.0"] } }
+    env: BS=cmake CXX=clang++-6.0
+    addons: { apt: { packages: ["clang-6.0", "libstdc++-6-dev", "gdb"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-6.0"] } }
+
+  - os: linux
+    dist: trusty
+    env: BS=cmake CXX=clang++-7
+    addons: { apt: { packages: ["clang-7", "libstdc++-7-dev", "gdb"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-7"] } }
+
+  - os: linux
+    dist: trusty
+    env: BS=cmake CXX=clang++-7 LIBCXX=ON
+    addons: { apt: { packages: ["clang-7", "libstdc++-7-dev", "gdb"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-7"] } }
 
   - os: linux
     dist: trusty
@@ -88,6 +98,11 @@ matrix:
     env: BS=cmake CXX=g++-7
     addons: { apt: { packages: ["g++-7", "libstdc++-7-dev", "gdb"], sources: ["ubuntu-toolchain-r-test"] } }
 
+  - os: linux
+    dist: trusty
+    env: BS=cmake CXX=g++-8
+    addons: { apt: { packages: ["g++-8", "libstdc++-8-dev", "gdb"], sources: ["ubuntu-toolchain-r-test"] } }
+
   - os: osx
     osx_image: xcode7.3
     env: BS=cmake CXX=clang++
@@ -100,21 +115,29 @@ matrix:
     osx_image: xcode9.1
     env: BS=cmake CXX=clang++
 
+  - os: osx
+    osx_image: xcode10
+    env: BS=cmake CXX=clang++
+
+  - os: osx
+    osx_image: xcode10.1
+    env: BS=cmake CXX=clang++
+
 #
 # Bjam
 #
   - os: linux
     dist: trusty
-    env: BS=bjam TOOLSET=clang CXX=clang++-5.0
-    addons: { apt: { packages: ["clang-5.0", "libstdc++-6-dev", "gdb"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-5.0"] } }
+    env: BS=bjam TOOLSET=clang CXX=clang++-7
+    addons: { apt: { packages: ["clang-7", "libstdc++-7-dev", "gdb"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-7"] } }
 
   - os: linux
     dist: trusty
-    env: BS=bjam TOOLSET=gcc CXX=g++-7
-    addons: { apt: { packages: ["g++-7", "libstdc++-7-dev", "gdb"], sources: ["ubuntu-toolchain-r-test"] } }
+    env: BS=bjam TOOLSET=gcc CXX=g++-8
+    addons: { apt: { packages: ["g++-8", "libstdc++-8-dev", "gdb"], sources: ["ubuntu-toolchain-r-test"] } }
 
   - os: osx
-    osx_image: xcode9.1
+    osx_image: xcode10.1
     env: BS=bjam TOOLSET=clang CXX=clang++
 
 #
@@ -122,16 +145,16 @@ matrix:
 #
   - os: linux
     dist: trusty
-    env: BS=cmake VARIANT=analyze CXX=clang++-5.0 LIBCXX=ON
-    addons: { apt: { packages: ["clang-5.0", "libstdc++-6-dev", "gdb"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-5.0"] } }
+    env: BS=cmake VARIANT=analyze CXX=clang++-7 LIBCXX=ON
+    addons: { apt: { packages: ["clang-7", "libstdc++-7-dev", "gdb"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-7"] } }
 
   - os: linux
     dist: trusty
-    env: BS=cmake VARIANT=analyze CXX=g++-7
-    addons: { apt: { packages: ["g++-7", "libstdc++-7-dev", "gdb"], sources: ["ubuntu-toolchain-r-test"] } }
+    env: BS=cmake VARIANT=analyze CXX=g++-8
+    addons: { apt: { packages: ["g++-8", "libstdc++-8-dev", "gdb"], sources: ["ubuntu-toolchain-r-test"] } }
 
   - os: osx
-    osx_image: xcode9.1
+    osx_image: xcode10.1
     env: BS=cmake VARIANT=analyze CXX=clang++
 
 #
@@ -139,16 +162,16 @@ matrix:
 #
   - os: linux
     dist: trusty
-    env: BS=cmake MEMCHECK=valgrind CXX=clang++-4.0 LIBCXX=ON
-    addons: { apt: { packages: ["clang-4.0", "libstdc++-6-dev", "valgrind", "gdb"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-4.0"] } }
+    env: BS=cmake MEMCHECK=valgrind CXX=clang++-7 LIBCXX=ON
+    addons: { apt: { packages: ["clang-7", "libstdc++-7-dev", "valgrind", "gdb"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-7"] } }
 
   - os: linux
     dist: trusty
-    env: BS=cmake MEMCHECK=valgrind CXX=g++-7
-    addons: { apt: { packages: ["g++-7", "libstdc++-7-dev", "valgrind", "gdb"], sources: ["ubuntu-toolchain-r-test"] } }
+    env: BS=cmake MEMCHECK=valgrind CXX=g++-8
+    addons: { apt: { packages: ["g++-8", "libstdc++-8-dev", "valgrind", "gdb"], sources: ["ubuntu-toolchain-r-test"] } }
 
   - os: osx
-    osx_image: xcode9.1
+    osx_image: xcode10.1
     env: BS=cmake MEMCHECK=valgrind CXX=clang++
 
 #
@@ -156,25 +179,8 @@ matrix:
 #
   - os: linux
     dist: trusty
-    env: BS=bjam TOOLSET=gcc GCOV=gcov-7 VARIANT=coverage CXX=g++-7
-    addons: { apt: { packages: ["g++-7", "libstdc++-7-dev", "gdb"], sources: ["ubuntu-toolchain-r-test"] } }
-
-#
-# Benchmarks
-#
-  #- os: linux
-    #dist: trusty
-    #env: BS=cmake BENCHMARK=QUICK CXX=clang++-4.0 LIBCXX=ON
-    #addons: { apt: { packages: ["clang-4.0", "libstdc++-6-dev"], sources: ["ubuntu-toolchain-r-test", "llvm-toolchain-trusty-4.0"] } }
-
-  #- os: linux
-    #dist: trusty
-    #env: BS=cmake BENCHMARK=QUICK CXX=g++-7
-    #addons: { apt: { packages: ["g++-7", "libstdc++-7-dev"], sources: ["ubuntu-toolchain-r-test"] } }
-
-  #- os: osx
-    #osx_image: xcode9.1
-    #env: BS=cmake BENCHMARK=QUICK CXX=clang++
+    env: BS=bjam TOOLSET=gcc GCOV=gcov-7 VARIANT=coverage CXX=g++-8
+    addons: { apt: { packages: ["g++-8", "libstdc++-8-dev", "gdb"], sources: ["ubuntu-toolchain-r-test"] } }
 
 before_install:
   - git config --global user.name "Continuous Integration"

--- a/example/multiple_bindings.cpp
+++ b/example/multiple_bindings.cpp
@@ -51,8 +51,9 @@ struct example {
 
 int main() {
   // clang-format off
+  auto il = {1, 2, 3, 5, 8, 13, 21};
   auto injector = di::make_injector(
-    di::bind<int[]>().to({1, 2, 3, 5, 8, 13, 21})
+    di::bind<int[]>().to(il)
   , di::bind<interface* []>().to<implementation1, implementation2, interface, di::named<class Implementation2>>()
   , di::bind<interface>().to<implementation1>()  // <------------------/                         |
   , di::bind<interface>().named<class Implementation2>().to<implementation2>()  // <-------------/

--- a/example/user_guide/bind_multiple_bindings_initializer_list.cpp
+++ b/example/user_guide/bind_multiple_bindings_initializer_list.cpp
@@ -30,8 +30,9 @@ struct impl1 : i1 {
 
 int main() {
   // clang-format off
+  auto il = {1, 2, 3};
   auto injector = di::make_injector(
-    di::bind<int[]>().to({1, 2, 3}) // or int*[]
+    di::bind<int[]>().to(il) // or di::bind<int*[]>.to(il)
   );
   // clang-format on
 

--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -1715,10 +1715,10 @@ class dependency : dependency_base,
     return dependency<TScope, array<type>, array<type, Ts...>, TName, TPriority, TCtor>{};
   }
   template <class T, __BOOST_DI_REQUIRES_MSG(concepts::boundable<TExpected, T>) = 0>
-  auto to(std::initializer_list<T>&& object) noexcept {
+  auto to(std::initializer_list<T> il) noexcept {
     using type = aux::remove_pointer_t<aux::remove_extent_t<TExpected>>;
     using dependency = dependency<scopes::instance, array<type>, std::initializer_list<T>, TName, TPriority, TCtor>;
-    return dependency{object};
+    return dependency{il};
   }
   template <class T, __BOOST_DI_REQUIRES(externable<T>::value && !aux::is_callable<T>::value) = 0,
             __BOOST_DI_REQUIRES_MSG(concepts::boundable<deduce_traits_t<TExpected, T>, aux::decay_t<T>, aux::valid<>>) = 0>

--- a/include/boost/di/core/dependency.hpp
+++ b/include/boost/di/core/dependency.hpp
@@ -159,10 +159,10 @@ class dependency : dependency_base,
   }
 
   template <class T, __BOOST_DI_REQUIRES_MSG(concepts::boundable<TExpected, T>) = 0>
-  auto to(std::initializer_list<T>&& object) noexcept {
+  auto to(std::initializer_list<T> il) noexcept {
     using type = aux::remove_pointer_t<aux::remove_extent_t<TExpected>>;
     using dependency = dependency<scopes::instance, array<type>, std::initializer_list<T>, TName, TPriority, TCtor>;
-    return dependency{object};
+    return dependency{il};
   }
 
   template <class T, __BOOST_DI_REQUIRES(externable<T>::value && !aux::is_callable<T>::value) = 0,

--- a/test/ft/di_bind.cpp
+++ b/test/ft/di_bind.cpp
@@ -806,7 +806,8 @@ test multi_bindings_with_initializer_list = [] {
     expect(*(std::next(it, 3)) == 4);
   };
 
-  auto injector = di::make_injector(di::bind<int[]>().to({1, 2, 3, 4}));
+  auto il = {1, 2, 3, 4};
+  auto injector = di::make_injector(di::bind<int[]>().to(il));
 
   test(injector.create<std::vector<int>>());
   test(injector.create<std::set<int>>());
@@ -822,7 +823,8 @@ test multi_bindings_with_initializer_list_with_ptr_type = [] {
     expect(*(std::next(it, 3)) == 4);
   };
 
-  auto injector = di::make_injector(di::bind<int *[]>().to({1, 2, 3, 4}));
+  auto il = {1, 2, 3, 4};
+  auto injector = di::make_injector(di::bind<int *[]>().to(il));
 
   test(injector.create<std::vector<int>>());
   test(injector.create<std::set<int>>());

--- a/test/ft/di_config.cpp
+++ b/test/ft/di_config.cpp
@@ -197,7 +197,8 @@ test constructible_policy_must_be_bound_array = [] {
     c(std::vector<int>, const std::set<float>&, std::vector<std::unique_ptr<i1>>, double /*not bound*/) {}
   };
 
-  const auto injector = di::make_injector<must_be_bound>(di::bind<float[]>().to({1.f, 2.f, 3.f, 4.f}), di::bind<int>().to(42),
+  auto il = {1.f, 2.f, 3.f, 4.f};
+  const auto injector = di::make_injector<must_be_bound>(di::bind<float[]>().to(il), di::bind<int>().to(42),
                                                          di::bind<int[]>().to<int, int>(), di::bind<i1>().to<impl1>(),
                                                          di::bind<impl1>().in(di::unique), di::bind<i1* []>().to<i1, impl1>());
 

--- a/test/ft/di_errors.cpp
+++ b/test/ft/di_errors.cpp
@@ -370,7 +370,10 @@ test bind_not_compatible_initializer_list = [] {
 #endif
                         );
 
-  expect_compile_fail("", errors_, int main() { di::make_injector(di::bind<int[]>().to({"a", "b"})); });
+  expect_compile_fail("", errors_, int main() {
+    auto il = {"a", "b"};
+    di::make_injector(di::bind<int[]>().to(il));
+  });
 };
 
 #if defined(__cpp_variable_templates)
@@ -385,7 +388,10 @@ test bind_not_compatible_initializer_list_v = [] {
 #endif
                         );
 
-  expect_compile_fail("", errors_, int main() { di::make_injector(di::bind<int[]>.to({"a", "b"})); });
+  expect_compile_fail("", errors_, int main() {
+    auto il = {"a", "b"};
+    di::make_injector(di::bind<int[]>.to(il));
+  });
 };
 #endif
 

--- a/test/ft/di_injector.cpp
+++ b/test/ft/di_injector.cpp
@@ -400,7 +400,8 @@ test exposed_named_ref = [] {
 };
 
 test exposed_multi_bindings = [] {
-  di::injector<std::set<int>, std::vector<int>> injector = di::make_injector(di::bind<int[]>().to({1, 2, 3}));
+  auto il = {1, 2, 3};
+  di::injector<std::set<int>, std::vector<int>> injector = di::make_injector(di::bind<int[]>().to(il));
   auto v = injector.create<std::vector<int>>();
   expect(3 == v.size());
   expect(1 == v[0]);
@@ -416,8 +417,9 @@ test exposed_multi_bindings = [] {
 };
 
 test exposed_multi_bindings_expose = [] {
+  auto il = {1, 2, 3};
   di::injector<BOOST_DI_EXPOSE(std::set<int>), BOOST_DI_EXPOSE(std::vector<int>)> injector =
-      di::make_injector(di::bind<int[]>().to({1, 2, 3}));
+      di::make_injector(di::bind<int[]>().to(il));
   expect(3 == injector.create<std::vector<int>>().size());
   expect(3 == injector.create<std::set<int>>().size());
 };


### PR DESCRIPTION
Problem:
- clang6/clang7/gcc8/xcode10 aren't tested using travis.

Solution:
- Extend travis matrix with the newest compilers.
