### PR TITLE
:bug: [scopes] Fix for singleton interface/implementation query

### DIFF
--- a/example/multiple_bindings.cpp
+++ b/example/multiple_bindings.cpp
@@ -66,5 +66,5 @@ int main() {
   assert(injector.create<std::set<int>>().size() == 7);
 
   assert(injector.create<std::vector<std::shared_ptr<interface>>>().size() == 4);
-  assert(injector.create<std::set<std::shared_ptr<interface>>>().size() == 4);
+  assert(injector.create<std::set<std::shared_ptr<interface>>>().size() == 2);  // unique instances
 }

--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -1852,9 +1852,8 @@ class stack_over_heap {
 }
 namespace scopes {
 class singleton {
- public:
-  template <class, class T, class = decltype(aux::has_shared_ptr__(aux::declval<T>()))>
-  class scope {
+  template <class T, class = decltype(aux::has_shared_ptr__(aux::declval<T>()))>
+  class scope_impl {
    public:
     template <class T_, class>
     using is_referable = typename wrappers::shared<singleton, T&>::template is_referable<T_>;
@@ -1873,8 +1872,8 @@ class singleton {
       return wrappers::shared<singleton, T&>(object);
     }
   };
-  template <class _, class T>
-  class scope<_, T, aux::true_type> {
+  template <class T>
+  class scope_impl<T, aux::true_type> {
    public:
     template <class T_, class>
     using is_referable = typename wrappers::shared<singleton, T>::template is_referable<T_>;
@@ -1893,6 +1892,10 @@ class singleton {
       return wrappers::shared<singleton, T_, std::shared_ptr<T_>&>{object};
     }
   };
+
+ public:
+  template <class, class T>
+  using scope = scope_impl<T>;
 };
 }
 static constexpr __BOOST_DI_UNUSED scopes::singleton singleton{};

--- a/include/boost/di/scopes/singleton.hpp
+++ b/include/boost/di/scopes/singleton.hpp
@@ -15,9 +15,8 @@
 namespace scopes {
 
 class singleton {
- public:
-  template <class, class T, class = decltype(aux::has_shared_ptr__(aux::declval<T>()))>
-  class scope {
+  template <class T, class = decltype(aux::has_shared_ptr__(aux::declval<T>()))>
+  class scope_impl {
    public:
     template <class T_, class>
     using is_referable = typename wrappers::shared<singleton, T&>::template is_referable<T_>;
@@ -39,8 +38,8 @@ class singleton {
     }
   };
 
-  template <class _, class T>
-  class scope<_, T, aux::true_type> {
+  template <class T>
+  class scope_impl<T, aux::true_type> {
    public:
     template <class T_, class>
     using is_referable = typename wrappers::shared<singleton, T>::template is_referable<T_>;
@@ -61,6 +60,10 @@ class singleton {
       return wrappers::shared<singleton, T_, std::shared_ptr<T_>&>{object};
     }
   };
+
+ public:
+  template <class, class T>
+  using scope = scope_impl<T>;
 };
 
 }  // namespace scopes

--- a/test/ft/di_bind.cpp
+++ b/test/ft/di_bind.cpp
@@ -215,7 +215,7 @@ test any_of_with_scope_split = [] {
   };
 
   test(di::unique, false);
-  test(di::singleton, false);
+  test(di::singleton, true);
 };
 
 test any_of_unique = [] {


### PR DESCRIPTION
Problem:
- Singleton returns different instances when quired for interface/implementation.

Solution:
- Remove the type of singleton scope in order to return the same instance.

Problem:
-

Solution:
-

Issue: #

Reviewers:
@