### PR TITLE
:bug: [docs] FIx #69 inheritance example doesn't build

### DIFF
--- a/doc/themes/boost-experimental/js/cpp.js
+++ b/doc/themes/boost-experimental/js/cpp.js
@@ -78,6 +78,10 @@ function compile_and_run(id) {
       if (found != null) {
         code_files += ', { "file" : "' + found[1] + '", "code" : ' + JSON.stringify(get_cpp_file("https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/include/" + found[1])) + ' }'
       }
+      var local = lines[line].match(/#include "(.*)"/);
+      if (local != null) {
+        code_files += ', { "file" : "' + local[1] + '", "code" : ' + JSON.stringify(get_cpp_file("https://raw.githubusercontent.com/boost-experimental/di/cpp14/" + local[1])) + ' }'
+      }
     }
     code_files += ']';
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -10,6 +10,8 @@ function(example example)
     add_test(example.${tmp} example.${tmp})
 endfunction()
 
+include_directories(..)
+
 example(annotations)
 example(automatic_injection)
 example(bind_non_owning_ptr)

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -13,6 +13,7 @@ project boost.di :
     requirements
         <include>../include
         <include>.
+        <include>..
 ;
 
 rule example ( src + : cxxflags * : property * ) {

--- a/example/polymorphism/concepts.cpp
+++ b/example/polymorphism/concepts.cpp
@@ -7,7 +7,7 @@
 #include <cassert>
 #include <sstream>
 
-#include "common/config.hpp"
+#include "example/polymorphism/common/config.hpp"
 
 //<-
 #if defined(__cpp_concepts)

--- a/example/polymorphism/inheritance.cpp
+++ b/example/polymorphism/inheritance.cpp
@@ -8,7 +8,7 @@
 #include <memory>
 #include <sstream>
 
-#include "common/config.hpp"
+#include "example/polymorphism/common/config.hpp"
 
 /*<<Dynamic polymorphism - inheritance>>*/
 class Drawable {

--- a/example/polymorphism/templates.cpp
+++ b/example/polymorphism/templates.cpp
@@ -7,7 +7,7 @@
 #include <cassert>
 #include <sstream>
 
-#include "common/config.hpp"
+#include "example/polymorphism/common/config.hpp"
 
 /*<<Static polymorphism - templates>>*/
 template <typename TDrawable = class Drawable>

--- a/example/polymorphism/type_erasure.cpp
+++ b/example/polymorphism/type_erasure.cpp
@@ -10,7 +10,7 @@
 #include <sstream>
 #include <type_traits>
 
-#include "common/config.hpp"
+#include "example/polymorphism/common/config.hpp"
 
 /*<<Type erasure>>*/
 class Drawable {

--- a/example/polymorphism/variant.cpp
+++ b/example/polymorphism/variant.cpp
@@ -9,7 +9,7 @@
 #include <sstream>
 #include <variant>
 
-#include "common/config.hpp"
+#include "example/polymorphism/common/config.hpp"
 
 struct Square {
   void draw(std::ostream& out) const { out << "Square"; }


### PR DESCRIPTION
Problem:
- Locally included files aren't sent to Wandbox when building cpp files.

Solution:
- Identify local includes and send them to Wandbox.