### PR TITLE
Fix syntax errors and add run links

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ int main() {
   injector.create<example>();
 }
 ```
+[Run this example on Wandbox](https://wandbox.org/permlink/Dpz6Isld1wxp3p5X).
 
 <p align="center">
 <table>
@@ -103,7 +104,7 @@ retq
 
 ```cpp
 struct interface {
-  virtual ~iworld() noexcept = default;
+  virtual ~interface() noexcept = default;
   virtual int get() const = 0;
 };
 
@@ -126,6 +127,7 @@ int main() {
   injector.create<std::unique_ptr<example>>();
 }
 ```
+[Run this example on Wandbox](https://wandbox.org/permlink/4yBTlH1jvdrsRPes).
 
 <p align="center">
 <table>
@@ -172,17 +174,18 @@ retq
 #### Quick guide - Bind templates
 
 ```cpp
-template<class TPolicy = class TErrorPolicy>
-class simple_updater : TPolicy {
-  void update() {
-    TPolicy::on("update");
+template<class ErrorPolicy = class TErrorPolicy>
+class simple_updater {
+public:
+  void update() const {
+    ErrorPolicy::on("update");
   }
 };
 
-template<class T = class TUpdater>
+template<class Updater = class TUpdater>
 class example {
 public:
-  explicit example(const TUpdater& updater)
+  explicit example(const Updater& updater)
     : updater(updater)
   { }
 
@@ -191,23 +194,26 @@ public:
   }
 
 private:
-  const TUpdater& updater;
+  const Updater& updater;
 };
 
 int main() {
   struct throw_policy {
-    void on(std::string_view str) {
+    static void on(const std::string& str) {
       throw std::runtime_error(str);
     }
   };
+
   const auto injector = di::make_injector(
     di::bind<class TErrorPolicy>.to<throw_policy>(),
     di::bind<class TUpdater>.to<simple_updater>()
   );
 
   injector.create<example>().update();
+  // Terminates with an uncaught exception because of our bound error policy
 }
 ```
+[Run this example on Wandbox](https://wandbox.org/permlink/mAzJQD8cTwboIxIx).
 
 <p align="center">
 <table>
@@ -258,9 +264,14 @@ struct Streamable {
 template<class Exchange = Streamable(class ExchangeStream)
          class Engine   = Streamable(class EngineStream)>
 class example {
+public:
   example(Exchange exchange, Engine engine)
-    : exchange(exchange), engine(engine)
+    : exchange(std::move(exchange)), engine(std::move(engine))
   { }
+  
+private:
+  Exchange exchange;
+  Engine engine;
 };
 
 int main() {
@@ -272,6 +283,7 @@ int main() {
   injector.create<example>();
 }
 ```
+[Run this example on Wandbox](https://wandbox.org/permlink/9QZTRsLkPNholmpj).
 
 <p align="center">
 <table>


### PR DESCRIPTION
Problem:
-Syntax errors in Readme.md examples. (Same as previous PR, but I'm working all from the GitHub web UI right now, so I squashed my commits by creating a new branch. :-/ )

Solution:
- Fix errors. Add Wandbox links that show complete working example for each.
