### PR TITLE
Improved new uml_dumper extension

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -37,6 +37,7 @@ example(multiple_interfaces)
 example(pool_provider)
 example(scopes)
 example(try_it)
+example(uml_dumper_2)
 
 example(polymorphism/concepts)
 example(polymorphism/inheritance)

--- a/example/uml_dumper_2.cpp
+++ b/example/uml_dumper_2.cpp
@@ -1,0 +1,85 @@
+
+#include <boost/di.hpp>
+#include <extension/include/boost/di/extension/policies/uml_dumper_2.hpp>
+#include <extension/include/boost/di/extension/scopes/shared.hpp>
+#include <cassert>
+#include <iostream>
+
+namespace di = boost::di;
+
+namespace complex {
+
+struct n{};
+struct m{};
+struct l{ l(n&){} };
+struct k{ k(m&, n&){} };
+struct j{ j(m&){} };
+struct i{ i(m&){} };
+struct h{ h(n&){} };
+struct g{};
+struct f{ f(l&){} };
+struct e{};
+struct d{ d(j&, k&){} };
+struct c{ c(g&, h&, i&){} };
+struct b{ b(e&, f&, g&){} };
+struct a{ a(b&, l&, c&, d&){} };
+
+auto get_injector()
+{
+  // clang-format off
+  return di::make_injector<di::extension::uml_dumper_2>(
+         di::bind<n>().in(di::extension::shared)
+       , di::bind<m>().in(di::extension::shared)
+       , di::bind<l>().in(di::extension::shared)
+       , di::bind<k>().in(di::extension::shared)
+       , di::bind<j>().in(di::extension::shared)
+       , di::bind<i>().in(di::extension::shared)
+       , di::bind<h>().in(di::extension::shared)
+       , di::bind<g>().in(di::extension::shared)
+       , di::bind<f>().in(di::extension::shared)
+       , di::bind<e>().in(di::extension::shared)
+       , di::bind<d>().in(di::extension::shared)
+       , di::bind<c>().in(di::extension::shared)
+       , di::bind<b>().in(di::extension::shared)
+       , di::bind<a>().in(di::extension::shared)
+      );
+      // clang-format off
+}
+
+} //namespace complex
+
+namespace simple {
+
+struct e{};
+struct d{};
+struct c{};
+struct b{};
+struct a{ a(b&, c&){} };
+
+auto get_injector()
+{
+  // clang-format off
+  return di::make_injector<di::extension::uml_dumper_2>(
+         di::bind<e>().in(di::extension::shared)
+       , di::bind<d>().in(di::extension::shared)
+       , di::bind<c>().in(di::extension::shared)
+       , di::bind<b>().in(di::extension::shared)
+       , di::bind<a>().in(di::extension::shared)
+      );
+      // clang-format off
+}
+
+} //namespace complex
+
+int main() {
+  //using namespace simple;
+  using namespace complex;
+
+  const auto injector = get_injector();
+
+  //std::cout << "@startuml uml_dumper.png" << std::endl;
+
+  injector.create<a>();
+
+  //std::cout << "@enduml" << std::endl;
+}

--- a/example/uml_dumper_2.cpp
+++ b/example/uml_dumper_2.cpp
@@ -24,10 +24,10 @@ struct c{ c(g&, h&, i&){} };
 struct b{ b(e&, f&, g&){} };
 struct a{ a(b&, l&, c&, d&){} };
 
-auto get_injector()
+auto& get_injector()
 {
   // clang-format off
-  return di::make_injector<di::extension::uml_dumper_2>(
+  static auto ject{di::make_injector<di::extension::uml_dumper>(
          di::bind<n>().in(di::extension::shared)
        , di::bind<m>().in(di::extension::shared)
        , di::bind<l>().in(di::extension::shared)
@@ -42,8 +42,9 @@ auto get_injector()
        , di::bind<c>().in(di::extension::shared)
        , di::bind<b>().in(di::extension::shared)
        , di::bind<a>().in(di::extension::shared)
-      );
+      )};
       // clang-format off
+  return ject;
 }
 
 } //namespace complex
@@ -56,10 +57,11 @@ struct c{};
 struct b{};
 struct a{ a(b&, c&){} };
 
-auto get_injector()
+auto& get_injector()
 {
+
   // clang-format off
-  return di::make_injector<di::extension::uml_dumper_2>(
+  static auto ject = di::make_injector<di::extension::uml_dumper>(
          di::bind<e>().in(di::extension::shared)
        , di::bind<d>().in(di::extension::shared)
        , di::bind<c>().in(di::extension::shared)
@@ -67,6 +69,7 @@ auto get_injector()
        , di::bind<a>().in(di::extension::shared)
       );
       // clang-format off
+  return ject;
 }
 
 } //namespace complex
@@ -75,7 +78,7 @@ int main() {
   //using namespace simple;
   using namespace complex;
 
-  const auto injector = get_injector();
+  const auto& injector{get_injector()};
 
   //std::cout << "@startuml uml_dumper.png" << std::endl;
 

--- a/extension/include/boost/di/extension/policies/uml_dumper_2.hpp
+++ b/extension/include/boost/di/extension/policies/uml_dumper_2.hpp
@@ -1,0 +1,167 @@
+//
+// Copyright (c) 2012-2019 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <typeinfo>
+#include <vector>
+#include <map>
+#include <memory>
+
+#include "boost/di.hpp"
+
+//#define LOG(STREAM) std::cout << "DEBUG " << STREAM << std::endl;
+
+#ifndef LOG
+#  define LOG(STREAM)
+#endif
+BOOST_DI_NAMESPACE_BEGIN
+namespace extension {
+
+struct item_t
+{
+  std::string name;
+  int max_childs;
+};
+
+using items_t = std::vector<item_t>;
+
+struct node_t;
+
+using node_ptr_t = std::shared_ptr<node_t>;
+using nodes_t = std::vector<node_ptr_t>;
+
+struct node_t
+{
+  std::string name;
+  int max_childs;
+  nodes_t childs;
+};
+
+////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////
+
+items_t items;
+
+///////////////////
+
+auto print_tree_impl(const node_ptr_t& root, std::map<std::string, bool>& visited) -> void
+{
+  if(visited.find(root->name) != visited.cend())
+  {
+    return;
+  }
+
+  visited[root->name] = true;
+  for(const auto& c : root->childs)
+  {
+    std::cout << "\"" << root->name << "\" ..> \"" << c->name << "\"" << std::endl;
+  }
+
+  for(const auto& c : root->childs)
+  {
+    print_tree_impl(c, visited);
+  }
+}
+
+auto print_tree(const node_ptr_t& root) -> void
+{
+  std::map<std::string, bool> visited;
+  print_tree_impl(root, visited);
+}
+
+auto tree_find(node_ptr_t root, const std::string& name) -> node_ptr_t
+{
+  if(root->name == name)
+  {
+    return root;
+  }
+  for(auto c : root->childs)
+  {
+    auto found = tree_find(c, name);
+    if(found != nullptr)
+    {
+      return found;
+    }
+  }
+  return nullptr;
+}
+
+auto make_tree_impl(const items_t& items, int& idx, node_ptr_t root, node_ptr_t node) -> void
+{
+  if(items.empty() || idx >= (int)items.size()) return;
+
+  node->name = items[idx].name;
+  node->max_childs = items[idx].max_childs;
+
+  LOG("make_tree_impl() idx: " << idx << " name: " << node->name)
+
+  for(int i = 0; i < node->max_childs; i++)
+  {
+    idx++;
+    auto child_node_name = items[idx].name;
+    auto existing_child = tree_find(root, child_node_name);
+
+    LOG("make_tree_impl() node->name " << node->name << " child: idx: " << idx << " name: " << child_node_name << "  exists: " << ((existing_child != nullptr) ? "true" : "false"))
+    if(existing_child != nullptr )
+    {
+      node->childs.push_back(existing_child);
+    }
+    else
+    {
+      auto child = std::make_shared<node_t>();
+      node->childs.push_back(child);
+      make_tree_impl(items, idx, root, child);
+    }
+  }
+  if(node->max_childs == 0)
+  {
+    LOG("make_tree_impl() no childs")
+  }
+}
+
+auto make_tree(const items_t& items) -> node_ptr_t
+{
+  auto root = std::make_shared<node_t>();
+  int idx = 0;
+
+  make_tree_impl(items, idx, root, root);
+
+  return root;
+}
+
+
+
+
+class uml_dumper_2 : public config {
+ public:
+
+  ~uml_dumper_2()
+  {
+    auto tree = make_tree(items);
+    print_tree(tree);
+  }
+
+  static auto policies(...) noexcept {
+
+    return make_policies([&](auto type) {
+      using T = decltype(type);
+      using given = typename T::given;
+
+      item_t item;
+      item.name = std::string{typeid(given).name()};
+      item.max_childs = T::arity::value;
+
+      //LOG("make_policies() name " << item.name << " childs " << item.max_childs)
+      items.push_back(item);
+    });
+  }
+};
+
+}  // namespace extension
+BOOST_DI_NAMESPACE_END


### PR DESCRIPTION
Problem:
- Showed wrong graph when dependencies are more complex
before (uml_dumper.hpp ):
![uml_dumper_org_all](https://user-images.githubusercontent.com/1706857/51787488-f14f3880-2172-11e9-8abe-a78afc74e656.png)


Solution:
- rebuilding the dependency graph and then generating plantuml output
after (uml_dumper_2.hpp):
![uml_dumper](https://user-images.githubusercontent.com/1706857/51787503-15ab1500-2173-11e9-8214-169673ba0c70.png)


Only tested on gcc 8.2.1

I put this here, as I think it might help others!
This is **not the cleanest or best implementation**, but It shows the idea and solves the problem.


