### PR TITLE
Fix __has_include using on Visual Studio.

### DIFF
--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -43,7 +43,9 @@ BOOST_DI_CFG_FWD
   {}
 #elif defined(_MSC_VER)
 #define __MSVC__
+#if !defined(_MSVC_LANG) || (_MSVC_LANG < 201703L)
 #define __has_include(...) 0
+#endif
 #define __BOOST_DI_UNUSED
 #define __BOOST_DI_DEPRECATED(...) __declspec(deprecated(__VA_ARGS__))
 #define __BOOST_DI_TYPE_WKND(T) (T &&)

--- a/include/boost/di/aux_/compiler.hpp
+++ b/include/boost/di/aux_/compiler.hpp
@@ -28,7 +28,9 @@
   {}
 #elif defined(_MSC_VER)  // msvc
 #define __MSVC__
+#if !defined(_MSVC_LANG) || (_MSVC_LANG < 201703L)
 #define __has_include(...) 0
+#endif
 #define __BOOST_DI_UNUSED
 #define __BOOST_DI_DEPRECATED(...) __declspec(deprecated(__VA_ARGS__))  // error C2059: syntax error: '<L_ATTRIBUTE_SPECIFIER>'
 #define __BOOST_DI_TYPE_WKND(T) (T &&)


### PR DESCRIPTION
Problem:
- We couldn't use __has_include preprocessor directive after "di.hpp" included in Visual Studio projects that support C++17.

Solution:
- Added conditional compilation for __has_include macro definition.
