### PR TITLE
:new: [example/polymorphism] Drawable example using std::function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,10 +104,6 @@ matrix:
     addons: { apt: { packages: ["g++-8", "libstdc++-8-dev", "gdb"], sources: ["ubuntu-toolchain-r-test"] } }
 
   - os: osx
-    osx_image: xcode7.3
-    env: BS=cmake CXX=clang++
-
-  - os: osx
     osx_image: xcode8.3
     env: BS=cmake CXX=clang++
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -41,6 +41,7 @@ example(scopes)
 example(try_it)
 
 example(polymorphism/concepts)
+example(polymorphism/function)
 example(polymorphism/inheritance)
 example(polymorphism/templates)
 example(polymorphism/type_erasure)

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -77,6 +77,7 @@ test-suite example :
 
 test-suite polymorphism :
     [ example polymorphism/concepts.cpp ]
+    [ example polymorphism/function.cpp ]
     [ example polymorphism/inheritance.cpp ]
     [ example polymorphism/templates.cpp ]
     [ example polymorphism/type_erasure.cpp ]

--- a/example/polymorphism/function.cpp
+++ b/example/polymorphism/function.cpp
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2012-2019 Kris Jusiak (kris at jusiak dot net)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+#include <cassert>
+#include <functional>
+#include <memory>
+#include <sstream>
+#include <type_traits>
+
+#include "example/polymorphism/common/config.hpp"
+
+/*<<function>>*/
+class Drawable : public std::function<void(std::ostream&)> {
+ public:
+  using std::function<void(std::ostream&)>::function;
+};
+
+class App {
+ public:
+  explicit App(const Drawable drawable) : drawable{drawable} {}
+  void draw(std::ostream& out) const { drawable(out); }
+
+ private:
+  const Drawable drawable;
+};
+
+struct Square {
+  void operator()(std::ostream& out) const { out << "Square"; }
+};
+
+struct Circle {
+  void operator()(std::ostream& out) const { out << "Circle"; }
+};
+
+int main() {
+  std::stringstream str{};
+  auto example = config().create<App>();
+  example.draw(str);
+  assert("Square" == str.str());
+}


### PR DESCRIPTION
Problem:
- There is no example of polymorphism using std::function.

Solution:
- Add `example/polymorphism/function.cpp` which demonstrates DI with std::function.

Problem:
-

Solution:
-

Issue: #

Reviewers:
@