### PR TITLE
:bug: Fix #404 - On gcc 9+, don't error on pedantic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,11 @@ target_include_directories(
 )
 
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -fno-exceptions -pedantic -pedantic-errors -Wall -Wextra -Werror")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -fno-exceptions -pedantic -pedantic-errors -Wall -Wextra -Werror")
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -fno-exceptions -pedantic -Wall -Wextra -Werror -Wno-error=pedantic")
+    endif()
 elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang OR ${CMAKE_CXX_COMPILER_ID} STREQUAL AppleClang)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -fno-exceptions -pedantic -pedantic-errors -Wall -Wextra -Werror")
 elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)


### PR DESCRIPTION
Problem:
- On gcc 9+, test.injections_named_parameters fails compilation

Solution:
- On gcc 9+, don't error on pedantic