### PR TITLE
:bug: Fix #404 - On gcc 9+, turn pedantic into warning where needed

### DIFF
--- a/example/annotations.cpp
+++ b/example/annotations.cpp
@@ -56,10 +56,17 @@ annotations2::annotations2(int i1, int i2, int i3) {
 template <char...>
 struct string {};
 
+#if (__GNUC__ >= 9)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wpedantic"
+#endif
 template <class T, T... Chars>
 constexpr auto operator""_s() {
   return string<Chars...>{};
 }
+#if (__GNUC__ >= 9)
+#pragma GCC diagnostic pop
+#endif
 #endif
 //->
 

--- a/extension/include/boost/di/extension/injections/named_parameters.hpp
+++ b/extension/include/boost/di/extension/injections/named_parameters.hpp
@@ -47,10 +47,17 @@ struct pair {
   long end{};
 };
 
+#if (__GNUC__ >= 9)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wpedantic"
+#endif
 template <class T, T... Chars>
 constexpr auto operator""_s() {
   return aux::integral_constant<long, const_hash(chars<Chars...>{}, sizeof...(Chars) + 1)>{};
 }
+#if (__GNUC__ >= 9)
+#pragma GCC diagnostic pop
+#endif
 
 long constexpr const_hash(char const* input, long m = 0, long i = 0) {
   return *input && i < m ? static_cast<long>(*input) + 33 * const_hash(input + 1, m, i + 1) : 5381;


### PR DESCRIPTION
Problem:
- On gcc 9+, test.injections_named_parameters and example annotations fail compilation

Solution:
- On gcc 9+, don't error in these spots for pedantic