### PR TITLE
Doc improvements

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,6 @@
+Don't View These Docs Through Github Code Tree
+==============================================
+
+These docs are translated and published at https://boost-experimental.github.io/di/.
+
+It's best to view these docs there, because certain features will only work there, such as buttons to load examples and slideshow presentations.

--- a/doc/benchmarks.md
+++ b/doc/benchmarks.md
@@ -1,4 +1,4 @@
-##Performance
+## Performance
 
 * **Run-time performance**
     * Environment
@@ -50,7 +50,7 @@ Legend:
 * 10 modules
 ```
 
-##C++ Libraries
+## C++ Libraries
 
 | **Library** | [Boost].DI ([See Performance](overview.md#performance)) | [dicpp] | [Google.Fruit] |
 | ----------- | -------- | ----- | ------------ |
@@ -68,7 +68,7 @@ cd benchmark && make
 ```
 ---
 
-##C++ vs Java vs C# Libraries
+## C++ vs Java vs C# Libraries
 
 | **Library** | [Boost].DI | [Google.Guice] | [Dagger2] | [Ninject] |
 | ----------  | -------- | ------------ | ------- | ------- |
@@ -117,7 +117,7 @@ cd benchmark && make
 ```
 ---
 
-##Usage of C++ vs Java vs C# Libraries
+## Usage of C++ vs Java vs C# Libraries
 
 | Library | Bind Interface | Performance |
 | ------- | -------------- | ----------- |

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -31,93 +31,93 @@
 
 ---
 
-###Hello World
+### Hello World
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/try_it.cpp)
 
-###Bindings
+### Bindings
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/bindings.cpp)
 
-###Dynamic Bindings
+### Dynamic Bindings
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/dynamic_bindings.cpp)
 
-###Forward Bindings
+### Forward Bindings
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/fwd_bindings.cpp)
 
-###Is Creatable
+### Is Creatable
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/is_creatable.cpp)
 
-###Multiple Bindings
+### Multiple Bindings
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/multiple_bindings.cpp)
 
-###Binding Non-owning Pointer
+### Binding Non-owning Pointer
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/bind_non_owning_ptr.cpp)
 
-###Binding Templates
+### Binding Templates
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/bind_templates.cpp)
 
-###Binding To Constructor
+### Binding To Constructor
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/bind_to_constructor.cpp)
 
-###Automatic Injection
+### Automatic Injection
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/automatic_injection.cpp)
 
-###Constructor Signature
+### Constructor Signature
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/constructor_signature.cpp)
 
-###Constructor Injection
+### Constructor Injection
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/constructor_injection.cpp)
 
-###Multiple Interface
+### Multiple Interface
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/multiple_interfaces.cpp)
 
-###Annotations
+### Annotations
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/annotations.cpp)
 
-###Deduce Scope
+### Deduce Scope
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/deduce_scope.cpp)
 
-###Custom Scope
+### Custom Scope
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/custom_scope.cpp)
 
-###Eager Singletons
+### Eager Singletons
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/eager_singletons.cpp)
 
-###Modules
+### Modules
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/modules.cpp)
 
-###Modules (hpp/cpp)
+### Modules (hpp/cpp)
 
 * See [https://github.com/boost-experimental/di/tree/cpp14/example/modules](https://github.com/boost-experimental/di/tree/cpp14/example/modules)
 
-###Custom Policy
+### Custom Policy
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/custom_policy.cpp)
 
-###Custom Provider
+### Custom Provider
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/custom_provider.cpp)
 
-###Pool Provider
+### Pool Provider
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/pool_provider.cpp)
 
-###Configuration
+### Configuration
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/configuration.cpp)
 
-###Polymorphism
+### Polymorphism
 * See [https://github.com/boost-experimental/di/tree/cpp14/example/polymorphism](https://github.com/boost-experimental/di/tree/cpp14/example/polymorphism)
 
-###Inheritance
+### Inheritance
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/polymorphism/inheritance.cpp)
 
-###Type Erasure
+### Type Erasure
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/polymorphism/type_erasure.cpp)
 
-###Function
+### Function
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/polymorphism/function.cpp)
 
-###Variant
+### Variant
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/polymorphism/variant.cpp)
 
-###Templates
+### Templates
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/polymorphism/templates.cpp)
 
-###Concepts
+### Concepts
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/example/polymorphism/concepts.cpp)

--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -21,64 +21,64 @@
 
 ---
 
-###Injector
+### Injector
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/injector.cpp)
 
-###Constructor Bindings
+### Constructor Bindings
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/bindings/constructor_bindings.cpp)
 
-###Contextual Bindings
+### Contextual Bindings
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/bindings/contextual_bindings.cpp)
 
-###Assisted Injection
+### Assisted Injection
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/injections/assisted_injection.cpp)
 
-###Extensible Injector
+### Extensible Injector
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/injections/extensible_injector.cpp)
 
-###Concepts
+### Concepts
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/injections/concepts.cpp)
 
-###Factory
+### Factory
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/injections/factory.cpp)
 
-###Shared Factory
+### Shared Factory
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/injections/shared_factory.cpp)
 
-###Lazy
+### Lazy
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/injections/lazy.cpp)
 
-###Named Parameters
+### Named Parameters
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/injections/named_parameters.cpp)
 
-###XML Injection
+### XML Injection
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/injections/xml_injection.cpp)
 
-###Serialize
+### Serialize
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/policies/serialize.cpp)
 
-###Types Dumper
+### Types Dumper
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/policies/types_dumper.cpp)
 
-###UML Dumper
+### UML Dumper
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/policies/uml_dumper.cpp)
 
 [![UML Dumper](images/uml_dumper.png)](images/uml_dumper.png)
 
-###Heap Provider
+### Heap Provider
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/providers/heap.cpp)
 
-###Mocks Provider
+### Mocks Provider
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/providers/mocks_provider.cpp)
 
-###Runtime Provider
+### Runtime Provider
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/providers/runtime_provider.cpp)
 
-###Scoped Scope
+### Scoped Scope
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/scopes/scoped.cpp)
 
-###Session Scope
+### Session Scope
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/scopes/session.cpp)
 
-###Shared Scope
+### Shared Scope
 ![CPP](https://raw.githubusercontent.com/boost-experimental/di/cpp14/extension/test/scopes/shared.cpp)

--- a/doc/index.md
+++ b/doc/index.md
@@ -306,7 +306,7 @@ but also can help you with...
 
 #### [Boost].DI
 
-* [CppCon 2018: \[Boost\].DI - Inject all the things!](https://www.youtube.com/watch?v=8HmjM3G8jhQ)
+* [CppCon 2018: \[Boost\].DI - Inject all the things!](https://www.youtube.com/watch?v=8HmjM3G8jhQ) | [Slides](https://boost-experimental.github.io/di/cppcon-2018)
 * [C++Now 2016: C++14 Dependency Injection Library](https://www.youtube.com/watch?v=comZthFv3PM) | [Slides](http://boost-experimental.github.io/di/cppnow-2016)
 * [Meeting C++ 2016: TDD/BDD and Dependency Injection](https://www.youtube.com/watch?v=T3uMcxhzRUE) | [Slides](http://boost-experimental.github.io/di/meetingcpp-2016)
 * [Boost your design with C++14 dependency injection](https://skillsmatter.com/skillscasts/9830-boost-your-design-with-c-plus-plus14-dependency-injection) | [Slides](http://boost-experimental.github.io/di/cpp-london-2017)

--- a/doc/index.md
+++ b/doc/index.md
@@ -19,7 +19,7 @@ Introduction
 <a href="../releases" class="btn btn-success" style="margin-bottom:8px;" role="button"><span class="fa fa-download"></span>&nbsp; <b>Download</b></a> &nbsp;&nbsp;&nbsp;&nbsp; <a href="CHANGELOG/index.html" class="btn btn-info" style="margin-bottom:8px;" role="button"><span class="fa fa-reorder"></span>&nbsp; <b>Changelog</b></a> &nbsp;&nbsp;&nbsp;&nbsp; <a href="tutorial/index.html" class="btn btn-warning" style="margin-bottom:8px;" role="button"><span class="fa fa-gear"></span>&nbsp; <b>Tutorial</b></a> &nbsp;&nbsp;&nbsp;&nbsp; <a href="examples/index.html" class="btn btn-danger" style="margin-bottom:8px;" role="button"><span class="fa fa-book"></span>&nbsp; <b>Examples</b></a>
 </div>
 
-#What is Dependency Injection?
+# What is Dependency Injection?
 > "Don't call us, we'll call you", Hollywood principle
 
 **[Dependency Injection](http://www.youtube.com/watch?v=IKD2-MAkXyQ) (DI)** involves passing (injecting) one or more dependencies (or services) to a dependent object (or client) which become part of the client’s state.
@@ -56,7 +56,7 @@ In short, DI is all about construction!
                                                               | };
 ```
 
-###Do I use a Dependency Injection already?
+### Do I use a Dependency Injection already?
 
 * If you are using constructors in your code then you are probably using some form of Dependency Injection too!
 
@@ -67,7 +67,7 @@ class Button {
 };
 ```
 
-###Do I use Dependency Injection correctly?
+### Do I use Dependency Injection correctly?
 
 Common mistakes when using Dependency Injection are:
 
@@ -170,13 +170,13 @@ class Board {
 };
 ```
 
-###Do I need a Dependency Injection?
+### Do I need a Dependency Injection?
 
 * DI provides loosely coupled code (separation of business logic and object creation)
 * DI provides easier to maintain code (different objects might be easily injected)
 * DI provides easier to test code (fakes objects might be injected)
 
-####STUPID vs SOLID - "Clean Code" Uncle Bob
+#### STUPID vs SOLID - "Clean Code" Uncle Bob
 
 <table>
   <tr><td><b>S</b></td><td>Singleton</td></tr>
@@ -197,7 +197,7 @@ class Board {
   <tr><td><b>D</b></td><td><b>Dependency inversion</b></td></tr>
 </table>
 
-###Do I need a DI Framework/Library?
+### Do I need a DI Framework/Library?
 
 Depending on a project and its scale you may put up with or without a DI library, however, in any project
 a DI framework may **free you** from maintaining a following (boilerplate) code...
@@ -214,7 +214,7 @@ app app_{controller_, user_};
 Notice that **ORDER** in which above dependencies are created is **IMPORTANT** as well as that
 **ANY** change in **ANY** of the objects constructor will **REQUIRE** a change in this code!
 
-####Manual DI - Wiring Mess (Avoid it by using [Boost].DI)
+#### Manual DI - Wiring Mess (Avoid it by using [Boost].DI)
 
 ```
 * Single Responsibility Principle
@@ -252,7 +252,7 @@ but also can help you with...
 * Understand code dependencies (See [UML Dumper](extensions.md#uml-dumper))
 * Restrict what types and how they should be created (See [Constructible Policy](user_guide.md#di_constructible))
 
-###Real Life examples?
+### Real Life examples?
 
 * [Match-3 Game](https://github.com/modern-cpp-examples/match3)
     * Simple web game in C++14 using SDL2 / Model View Controller / Meta State Machine / Dependency Injection / Range-V3 / Emscripten
@@ -268,7 +268,7 @@ but also can help you with...
 * [Experimental Boost.SML](http://boost-experimental.github.io/sml)
     * C++14 header only Meta State Machine library with no dependencies
 
-###Why [Boost].DI?
+### Why [Boost].DI?
 
 * [Boost].DI has none run-time overhead (See [Performance](overview.md#performance))
 * [Boost].DI compiles fast / **Faster than Java-[Dagger2]!** (See [Benchmarks](overview.md#benchmarks))
@@ -287,7 +287,7 @@ but also can help you with...
 
 <br /><br />
 
-###[Boost].DI design goals
+### [Boost].DI design goals
 
 * Be as fast as possible (See [Performance](overview.md#performance))
 * Compile as fast as possible (See [Benchmarks](overview.md#benchmarks))
@@ -296,13 +296,13 @@ but also can help you with...
 * Be as non-intrusive as possible (See [Injections](user_guide.md#injections))
 * Be easy to extend (See [Extensions](extensions.md))
 
-###Articles
+### Articles
 
 * [Inversion of Control Containers and the Dependency Injection pattern](http://martinfowler.com/articles/injection.html)
 * [DIP in the Wild](http://martinfowler.com/articles/dipInTheWild.html)
 * [Concepts driven design with Dependency Injection](http://boost-experimental.github.io/di/concepts-driven-design-with-di)
 
-###Videos
+### Videos
 
 * [Dependency Injection](https://www.youtube.com/watch?v=IKD2-MAkXyQ)
 * [The Clean Code Talks - Don't Look For Things!](https://www.youtube.com/watch?v=RlfLCWKxHJ0)
@@ -314,7 +314,7 @@ but also can help you with...
 * [The Future of Dependency Injection with Dagger 2](https://www.youtube.com/watch?v=plK0zyRLIP8)
 * [Design Patterns in C++: Creational](https://www.pluralsight.com/courses/design-patterns-cpp-creational)
 
-###Acknowledgements
+### Acknowledgements
 
 * Thanks to **Bartosz Kalinczuk** for code review and tips how to improve `[Boost].DI`
 * Thanks to **Kanstantsin Chernik** for all his contributions to `[Boost].DI`

--- a/doc/index.md
+++ b/doc/index.md
@@ -304,12 +304,17 @@ but also can help you with...
 
 ### Videos
 
-* [Dependency Injection](https://www.youtube.com/watch?v=IKD2-MAkXyQ)
-* [The Clean Code Talks - Don't Look For Things!](https://www.youtube.com/watch?v=RlfLCWKxHJ0)
+#### [Boost].DI
+
 * [CppCon 2018: \[Boost\].DI - Inject all the things!](https://www.youtube.com/watch?v=8HmjM3G8jhQ)
 * [C++Now 2016: C++14 Dependency Injection Library](https://www.youtube.com/watch?v=comZthFv3PM) | [Slides](http://boost-experimental.github.io/di/cppnow-2016)
 * [Meeting C++ 2016: TDD/BDD and Dependency Injection](https://www.youtube.com/watch?v=T3uMcxhzRUE) | [Slides](http://boost-experimental.github.io/di/meetingcpp-2016)
 * [Boost your design with C++14 dependency injection](https://skillsmatter.com/skillscasts/9830-boost-your-design-with-c-plus-plus14-dependency-injection) | [Slides](http://boost-experimental.github.io/di/cpp-london-2017)
+
+#### Dependency Injection In General
+
+* [Dependency Injection](https://www.youtube.com/watch?v=IKD2-MAkXyQ)
+* [The Clean Code Talks - Don't Look For Things!](https://www.youtube.com/watch?v=RlfLCWKxHJ0)
 * [A New Type of dependency injection](http://www.youtube.com/watch?v=oK_XtfXPkqw)
 * [The Future of Dependency Injection with Dagger 2](https://www.youtube.com/watch?v=plK0zyRLIP8)
 * [Design Patterns in C++: Creational](https://www.pluralsight.com/courses/design-patterns-cpp-creational)

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -1,4 +1,4 @@
-###Quick Start
+### Quick Start
 
 * Get [boost/di.hpp](https://raw.githubusercontent.com/boost-experimental/di/cpp14/include/boost/di.hpp) header
 ```sh
@@ -25,17 +25,17 @@ $CXX -std=c++14 ...
 git clone https://github.com/boost-experimental/di && cd di && make
 ```
 
-###Dependencies
+### Dependencies
 
 * No external dependencies are required (neither STL nor Boost)
 
-###Supported/Tested compilers
+### Supported/Tested compilers
 
 * [Clang-3.4+](https://travis-ci.org/boost-experimental/di)
 * [GCC-5.2+](https://travis-ci.org/boost-experimental/di)
 * [MSVC-2015+](https://ci.appveyor.com/project/krzysztof-jusiak/di)
 
-###Configuration
+### Configuration
 | Macro                             | Description |
 | --------------------------------- | ----------- |
 | `BOOST_DI_VERSION`                | Current version of [Boost].DI (ex. 1'0'0) |
@@ -45,20 +45,20 @@ git clone https://github.com/boost-experimental/di && cd di && make
 | `BOOST_DI_NAMESPACE_BEGIN`        | `namespace boost { namespace di { inline namespace v_1_0_0 {` |
 | `BOOST_DI_NAMESPACE_END`          | `}}}` |
 
-###Exception Safety
+### Exception Safety
 
 * [Boost].DI is not using exceptions internally and therefore might be compiled with `-fno-exceptions`.
 * Check [User Guide](user_guide.md) to verify which API's are marked `noexcept`.
 
-###Thread Safety
+### Thread Safety
 
 * [Boost].DI is thread safe.
 
-###Error Messages
+### Error Messages
 
 * [Boost].DI is designed to give great diagnostic errors. The examples below will show you the actual error messages for different scenarios. Check [`Concepts`](user_guide.md#concepts) to check it out.
 
-###Performance
+### Performance
 
 * [Boost].DI has none run-time overhead and compiles faster than Java's DI frameworks. Check [`Benchmarks`](benchmarks.md) to see more.
 

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -62,7 +62,7 @@ struct impl2 : i2 { void dummy2() override { } };
 struct impl : i1, i2 { void dummy1() override { } void dummy2() override { } };
 ```
 
-###Injector
+### Injector
 
 <a id="di_make_injector"></a>
 
@@ -215,7 +215,7 @@ conversion constructors `template<class I> T(I)` are not supported and have to b
 
 ---
 
-###Bindings
+### Bindings
 
 Bindings define dependencies configuration describing what types will be created
 and what values will be passed into them.
@@ -307,7 +307,7 @@ Check out also [instance] scope to read more about binding to values: `di::bind<
 
 <br /><br /><br /><hr />
 
-###Injections
+### Injections
 
 *Constructor Injection* is the most powerful of available injections.
 It guarantees initialized state of data members. [Boost].DI constructor injection is achieved without any additional work from the user.
@@ -500,7 +500,7 @@ It's useful for third party classes you don't have access to and which can't be 
 
 <br /><hr />
 
-###Annotations
+### Annotations
 
 Annotations are type properties specified in order to refer to a type by the name instead of the type it self.
 They are useful when constructor has more than one parameter of the same type.
@@ -561,7 +561,7 @@ Implementation of constructor doesn't require annotations, only constructor defi
 
 <br /><hr />
 
-###Scopes
+### Scopes
 
 ***Header***
 
@@ -865,7 +865,7 @@ Scope representing unique/per request value. A new instance will be provided eac
 
 <br /><hr />
 
-###Modules
+### Modules
 
 <a id="di_module"></a>
 
@@ -928,7 +928,7 @@ BOOST_DI_EXPOSE is a macro definition allowing to expose [named] parameters via 
 <br /><hr />
 
 
-###Providers
+### Providers
 
 ***Header***
 
@@ -1085,7 +1085,7 @@ Basic provider creates objects on the heap (always).
 
 <br /><br /><br /><hr />
 
-###Policies
+### Policies
 
 ***Header***
 
@@ -1219,7 +1219,7 @@ For example, `std::is_same<_, int>{} || std::is_constructible<_, int, int>{} || 
 
 <br /><br /><br /><hr />
 
-###Concepts
+### Concepts
 
 Concepts are types constraints which ensure that only given types which are satisfied by the constraint will be allowed.
 If type doesn't satisfy the concept short and descriptive error message is provided.
@@ -1506,7 +1506,7 @@ Suggestions are not supported/displayed by MSVC-2015.
 
 ---
 
-###Configuration
+### Configuration
 
 <a id="di_config"></a>
 --- ***di::config*** ---


### PR DESCRIPTION
Problem:
- I knew https://boost-experimental.github.io/di/ existed but hadn't looked through all of it.  I was first looking through `di/doc/` without realizing they were translated to be at least part of what was shown through the `gh-pages` branch at this link.

Solution:
- Add a `README.md` to tell users browsing the github source tree they should instead view the docs at the github.io website.
- Add spaces after header (`#`) syntax in some `.md` files missing the spacing, allowing them to be interpreted b git as headers rather than just showing them like `###This should have been a header`.
- Also split video list into subcategories of "[Boost].DI" and "Dependency Injection In General", and add missing link to slides for CppCon 2018 Inject all the things.