### PR TITLE
Use std::integer_sequence.

### DIFF
--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -236,7 +236,7 @@ template <int...>
 struct index_sequence {
   using type = index_sequence;
 };
-#if defined(__cpp_lib_integer_sequence)
+#if defined(__cpp_lib_integer_sequence) && defined(__GNUC__)
 template <int... Ns>
 index_sequence<Ns...> from_std(std::integer_sequence<int, Ns...>) {
   return {};

--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -236,6 +236,10 @@ template <int...>
 struct index_sequence {
   using type = index_sequence;
 };
+#if defined(__cpp_lib_integer_sequence)
+template <int... Ns> index_sequence<Ns...> from_std(std::integer_sequence<int, Ns...>) { return {}; }
+template <int N> using make_index_sequence = decltype(from_std(std::make_integer_sequence<int, N>{}));
+#else
 #if __has_builtin(__make_integer_seq)
 template <class T, T...>
 struct integer_sequence;
@@ -275,6 +279,7 @@ struct make_index_sequence_impl<10> : index_sequence<0, 1, 2, 3, 4, 5, 6, 7, 8, 
 #endif
 template <int N>
 using make_index_sequence = typename make_index_sequence_impl<N>::type;
+#endif
 }
 namespace placeholders {
 __BOOST_DI_UNUSED static const struct arg { } _{}; }

--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -237,8 +237,12 @@ struct index_sequence {
   using type = index_sequence;
 };
 #if defined(__cpp_lib_integer_sequence)
-template <int... Ns> index_sequence<Ns...> from_std(std::integer_sequence<int, Ns...>) { return {}; }
-template <int N> using make_index_sequence = decltype(from_std(std::make_integer_sequence<int, N>{}));
+template <int... Ns>
+index_sequence<Ns...> from_std(std::integer_sequence<int, Ns...>) {
+  return {};
+}
+template <int N>
+using make_index_sequence = decltype(from_std(std::make_integer_sequence<int, N>{}));
 #else
 #if __has_builtin(__make_integer_seq)
 template <class T, T...>

--- a/include/boost/di/aux_/utility.hpp
+++ b/include/boost/di/aux_/utility.hpp
@@ -102,6 +102,14 @@ struct index_sequence {
   using type = index_sequence;
 };
 
+#if defined(__cpp_lib_integer_sequence) && defined(__GNUC__)  // __pph__
+template <int... Ns>
+index_sequence<Ns...> from_std(std::integer_sequence<int, Ns...>) {
+  return {};
+}
+template <int N>
+using make_index_sequence = decltype(from_std(std::make_integer_sequence<int, N>{}));
+#else                                  // __pph__
 #if __has_builtin(__make_integer_seq)  // __pph__
 template <class T, T...>
 struct integer_sequence;
@@ -113,7 +121,7 @@ template <int N>
 struct make_index_sequence_impl {
   using type = typename __make_integer_seq<integer_sequence, int, N>::type;
 };
-#else   // __pph__
+#else                                  // __pph__
 template <int>
 struct make_index_sequence_impl;
 
@@ -153,6 +161,7 @@ struct make_index_sequence_impl<10> : index_sequence<0, 1, 2, 3, 4, 5, 6, 7, 8, 
 
 template <int N>
 using make_index_sequence = typename make_index_sequence_impl<N>::type;
+#endif  // __pph__
 
 }  // namespace aux
 


### PR DESCRIPTION
Problem:
BOOST_DI_CFG_CTOR_LIMIT_SIZE cannot be increased with gcc 9 and 8.

Issue #273 suggests to "#define __has_builtin(...) 1", but that doesn't work either. Apparently the original builtin is no longer available.

Solution:
~~`#include <utility>` when increasing~~ _Increase_ BOOST_DI_CFG_CTOR_LIMIT_SIZE and reuse std::integer_sequence.

Issue: #273 #271