### PR TITLE
Update msft compilers

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,14 +23,14 @@ environment:
 
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
-      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\
+      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Auxiliary\Build
       BS: cmake
       CMAKE_GENERATOR: Visual Studio 16 2019
       MEMCHECK: DRMEMORY
       PLATFORM: amd64
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\
+      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build
       BS: cmake
       CMAKE_GENERATOR: Visual Studio 16 2019
       MEMCHECK: DRMEMORY

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,38 +22,31 @@ environment:
   fast_finish: true
 
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC
-      BS: cmake
-      CMAKE_GENERATOR: Visual Studio 14 2015
-      MEMCHECK: DRMEMORY
-      PLATFORM: amd64
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build
-      BS: cmake
-      CMAKE_GENERATOR: Visual Studio 15 2017
-      MEMCHECK: DRMEMORY
-      PLATFORM: amd64
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build
-      BS: cmake
-      CMAKE_GENERATOR: Visual Studio 15 2017
-      MEMCHECK: DRMEMORY
-      PLATFORM: amd64
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\Preview\VC\Auxiliary\Build
-      BS: cmake
-      CMAKE_GENERATOR: Visual Studio 16 2019
-      MEMCHECK: DRMEMORY
-      PLATFORM: amd64
-
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
       VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\Preview\VC\Auxiliary\Build
       BS: cmake
       CMAKE_GENERATOR: Visual Studio 16 2019
+      MEMCHECK: DRMEMORY
+      PLATFORM: amd64
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\
+      BS: cmake
+      CMAKE_GENERATOR: Visual Studio 16 2019
+      MEMCHECK: DRMEMORY
+      PLATFORM: amd64
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build
+      BS: cmake
+      CMAKE_GENERATOR: Visual Studio 15 2017
+      MEMCHECK: DRMEMORY
+      PLATFORM: amd64
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC
+      BS: cmake
+      CMAKE_GENERATOR: Visual Studio 14 2015
       MEMCHECK: DRMEMORY
       PLATFORM: amd64
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,8 +10,8 @@ shallow_clone: true
 
 branches:
   except:
-  - benchmarks
-  - gh-pages
+    - benchmarks
+    - gh-pages
 
 cache:
   - C:\ProgramData\chocolatey\lib\cmake.portable -> .appveyor.yml
@@ -22,26 +22,40 @@ environment:
   fast_finish: true
 
   matrix:
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC
-    BS: cmake
-    CMAKE_GENERATOR: Visual Studio 14 2015
-    MEMCHECK: DRMEMORY
-    PLATFORM: amd64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC
+      BS: cmake
+      CMAKE_GENERATOR: Visual Studio 14 2015
+      MEMCHECK: DRMEMORY
+      PLATFORM: amd64
 
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build
-    BS: cmake
-    CMAKE_GENERATOR: Visual Studio 15 2017
-    MEMCHECK: DRMEMORY
-    PLATFORM: amd64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build
+      BS: cmake
+      CMAKE_GENERATOR: Visual Studio 15 2017
+      MEMCHECK: DRMEMORY
+      PLATFORM: amd64
 
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017 Preview
-    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\Preview\Community\VC\Auxiliary\Build
-    BS: cmake
-    CMAKE_GENERATOR: Visual Studio 15 2017
-    MEMCHECK: DRMEMORY
-    PLATFORM: amd64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build
+      BS: cmake
+      CMAKE_GENERATOR: Visual Studio 15 2017
+      MEMCHECK: DRMEMORY
+      PLATFORM: amd64
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\Preview\VC\Auxiliary\Build
+      BS: cmake
+      CMAKE_GENERATOR: Visual Studio 16 2019
+      MEMCHECK: DRMEMORY
+      PLATFORM: amd64
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
+      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\Preview\VC\Auxiliary\Build
+      BS: cmake
+      CMAKE_GENERATOR: Visual Studio 16 2019
+      MEMCHECK: DRMEMORY
+      PLATFORM: amd64
 
 matrix:
   fast_finish: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ environment:
 
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
-      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\Preview\VC\Auxiliary\Build
+      VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\
       BS: cmake
       CMAKE_GENERATOR: Visual Studio 16 2019
       MEMCHECK: DRMEMORY


### PR DESCRIPTION
Problem:
- There are new compiler releases available.

Solution:
- Add MSVC 2019/MSVC 2019 Preview.