### PR TITLE
Lazy extension is transparent for exceptions

### DIFF
--- a/extension/include/boost/di/extension/injections/lazy.hpp
+++ b/extension/include/boost/di/extension/injections/lazy.hpp
@@ -25,7 +25,7 @@ class lazy {
   template <class TInjector>
   explicit lazy(const TInjector &i) noexcept : injector_((void *)&i), f(create<TInjector>) {}
 
-  T get() const noexcept { return (*f)(injector_); }
+  T get() const { return (*f)(injector_); }
 
  private:
   const void *injector_ = nullptr;

--- a/extension/test/injections/lazy.cpp
+++ b/extension/test/injections/lazy.cpp
@@ -35,14 +35,34 @@ class example {
 };
 
 int main() {
-  /*<<define injector>>*/
-  // clang-format off
-  auto injector = di::make_injector(
-    di::bind<interface>().to<type_expensive_to_create>()
-  );
-  // clang-format on
+  {
+    /*<<define injector>>*/
+    // clang-format off
+    auto injector = di::make_injector(
+      di::bind<interface>().to<type_expensive_to_create>()
+    );
+    // clang-format on
 
-  /*<<create `example`>>*/
-  auto object = injector.create<example>();
-  object.initialize();
+    /*<<create `example`>>*/
+    auto object = injector.create<example>();
+    object.initialize();
+  }
+  {
+    /*<<define injector>>*/
+    // clang-format off
+    auto injector = di::make_injector(
+        di::bind<int>().to([]()->int{ throw 0; })
+    );
+    auto exception_thrown = false;
+    try {
+        auto lazy = injector.create<di::extension::lazy<int>>();
+        /*<<call throws>>*/
+        lazy.get();
+    }
+    catch (...) {
+        exception_thrown = true;
+    }
+    assert(exception_thrown);
+    // clang-format on
+  }
 }

--- a/extension/test/injections/lazy.cpp
+++ b/extension/test/injections/lazy.cpp
@@ -47,6 +47,7 @@ int main() {
     auto object = injector.create<example>();
     object.initialize();
   }
+#if defined(__EXCEPTIONS)
   {
     /*<<define injector>>*/
     // clang-format off
@@ -65,4 +66,5 @@ int main() {
     assert(exception_thrown);
     // clang-format on
   }
+#endif
 }

--- a/test/ft/di_bind.cpp
+++ b/test/ft/di_bind.cpp
@@ -868,7 +868,7 @@ class lazy {
   template <class TInjector>
   explicit lazy(const TInjector &i) noexcept : injector_((void *)&i), f(create<TInjector>) {}
 
-  T get() const noexcept { return (*f)(injector_); }
+  T get() const { return (*f)(injector_); }
 
  private:
   const void *injector_ = nullptr;


### PR DESCRIPTION
Problem:
- Lazy extension did not support exceptions

Solution:
- Remove `noexcept` from `lazy::get` to let exception through

Issue: #

Reviewers:
@krzysztof-jusiak 