### PR TITLE
Fix extensible injector

### DIFF
--- a/extension/include/boost/di/extension/injections/extensible_injector.hpp
+++ b/extension/include/boost/di/extension/injections/extensible_injector.hpp
@@ -29,12 +29,12 @@ class dependency_proxy : core::dependency_base,
   dependency_proxy(dependency_proxy& other) noexcept : orig_dependency_(other.orig_dependency_) {}
   dependency_proxy(dependency_proxy&& other) noexcept : orig_dependency_(other.orig_dependency_) {}
 
- protected:
   using scope_t = typename scope::template scope<expected, given>;
 
   template <class T, class TConfig>
   using is_referable = typename scope_t::template is_referable<T, TConfig>;
 
+protected:
   template <class T, class Name, class TProvider>
   static decltype(scope_t::template try_create<T, Name>(aux::declval<TProvider>())) try_create(const TProvider&);
 

--- a/extension/include/boost/di/extension/injections/extensible_injector.hpp
+++ b/extension/include/boost/di/extension/injections/extensible_injector.hpp
@@ -34,7 +34,6 @@ class dependency_proxy : core::dependency_base,
   template <class T, class TConfig>
   using is_referable = typename scope_t::template is_referable<T, TConfig>;
 
-protected:
   template <class T, class Name, class TProvider>
   static decltype(scope_t::template try_create<T, Name>(aux::declval<TProvider>())) try_create(const TProvider&);
 


### PR DESCRIPTION
Problem:
`is_referable` in `dependency_proxy` is not accessable
```

Error	C2248	'boost::di::v1_1_0::extension::dependency_proxy<boost::di::v1_1_0::scopes::instance,interface,boost::di::v1_1_0::extension::shared_factory_impl<T,false,TFunc>,boost::di::v1_1_0::no_name,void,boost::di::v1_1_0::core::none>::is_referable<const interface&,config>': cannot access protected member declared in class 'boost::di::v1_1_0::extension::dependency_proxy<boost::di::v1_1_0::scopes::instance,interface,boost::di::v1_1_0::extension::shared_factory_impl<T,false,TFunc>,boost::di::v1_1_0::no_name,void,boost::di::v1_1_0::core::none>'
```

Solution:
Just make it public. Unlike `dependency` there is no reason to hide these members

Issue: #

Reviewers:
@krzysztof-jusiak 