### PR TITLE
Fix __has_include

### DIFF
--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -43,7 +43,7 @@ BOOST_DI_CFG_FWD
   {}
 #elif defined(_MSC_VER)
 #define __MSVC__
-#if !defined(_MSVC_LANG) || (_MSVC_LANG < 201703L)
+#if !defined(__has_include)
 #define __has_include(...) 0
 #endif
 #define __BOOST_DI_UNUSED

--- a/include/boost/di/aux_/compiler.hpp
+++ b/include/boost/di/aux_/compiler.hpp
@@ -28,7 +28,7 @@
   {}
 #elif defined(_MSC_VER)  // msvc
 #define __MSVC__
-#if !defined(_MSVC_LANG) || (_MSVC_LANG < 201703L)
+#if !defined(__has_include)
 #define __has_include(...) 0
 #endif
 #define __BOOST_DI_UNUSED


### PR DESCRIPTION
Problem:
- `di.hpp` incorrectly redefines `__has_include`

Solution:
- Simply check if it is defined

Issue: #
`_has_include` is supported since VS 2017 15.3.
Version of VS is defined in `_MSVC_VER` while `_MSVC_LANG` defines c++ version.
So it should either be `#if !defined(_MSVC_VER) < 1911` or just simply `#if !defined(__has_include)`

https://docs.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance?view=vs-2019#compiler-features
https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019#microsoft-specific-predefined-macros

Reviewers:
@krzysztof-jusiak 