### PR TITLE
Fix bad "type name" in contextual binding for clang-cl

### DIFF
--- a/extension/include/boost/di/extension/bindings/contextual_bindings.hpp
+++ b/extension/include/boost/di/extension/bindings/contextual_bindings.hpp
@@ -13,13 +13,13 @@
 
 template <class T>
 auto get_type() {
-#if defined(_MSC_VER)
+#if defined(__clang__)
+  auto type = std::string{&__PRETTY_FUNCTION__[21]};
+  return type.substr(0, type.length() - 1);
+#elif defined(_MSC_VER)
   auto type = std::string{&__FUNCSIG__[28]};
   const auto i = type[0] == ' ' ? 1 : 0;
   return type.substr(i, type.length() - 7 - i);
-#elif defined(__clang__)
-  auto type = std::string{&__PRETTY_FUNCTION__[21]};
-  return type.substr(0, type.length() - 1);
 #elif defined(__GCC__)
   auto type = std::string{&__PRETTY_FUNCTION__[26]};
   return type.substr(0, type.length() - 1);


### PR DESCRIPTION
ditto as title, this will fix clang-cl seeing garbage like "[T " etc. As you see there's MSVC problem lately in #463 and I had to resort to using clang-cl. Thankfully all is good despite it is marginally slower.