### PR TITLE
:wrench: :arrow_up: [MSVC-16.5.4] Enable support for the newest MSVC …

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,6 +21,72 @@ environment:
   fast_finish: true
 
   matrix:
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
+    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Auxiliary\Build
+    BS: cmake
+    CMAKE_GENERATOR: Visual Studio 16 2019
+    MEMCHECK: DRMEMORY
+    PLATFORM: amd64
+    CXX_STANDARD: 14
+
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
+    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Auxiliary\Build
+    BS: cmake
+    CMAKE_GENERATOR: Visual Studio 16 2019
+    MEMCHECK: DRMEMORY
+    PLATFORM: amd64
+    CXX_STANDARD: 17
+
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
+    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Auxiliary\Build
+    BS: cmake
+    CMAKE_GENERATOR: Visual Studio 16 2019
+    MEMCHECK: DRMEMORY
+    PLATFORM: amd64
+    CXX_STANDARD: 20
+
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build
+    BS: cmake
+    CMAKE_GENERATOR: Visual Studio 16 2019
+    MEMCHECK: DRMEMORY
+    PLATFORM: amd64
+    CXX_STANDARD: 14
+
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build
+    BS: cmake
+    CMAKE_GENERATOR: Visual Studio 16 2019
+    MEMCHECK: DRMEMORY
+    PLATFORM: amd64
+    CXX_STANDARD: 17
+
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build
+    BS: cmake
+    CMAKE_GENERATOR: Visual Studio 16 2019
+    MEMCHECK: DRMEMORY
+    PLATFORM: amd64
+    CXX_STANDARD: 20
+
+
+
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build
+    BS: cmake
+    CMAKE_GENERATOR: Visual Studio 15 2017
+    MEMCHECK: DRMEMORY
+    PLATFORM: amd64
+    CXX_STANDARD: 14
+
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build
+    BS: cmake
+    CMAKE_GENERATOR: Visual Studio 15 2017
+    MEMCHECK: DRMEMORY
+    PLATFORM: amd64
+    CXX_STANDARD: 17
+
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     VSPATH: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC
     BS: cmake
@@ -28,70 +94,6 @@ environment:
     MEMCHECK: DRMEMORY
     PLATFORM: amd64
     CXX_STANDARD: 14
-
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build
-    BS: cmake
-    CMAKE_GENERATOR: Visual Studio 15 2017
-    MEMCHECK: DRMEMORY
-    PLATFORM: amd64
-    CXX_STANDARD: 14
-
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build
-    BS: cmake
-    CMAKE_GENERATOR: Visual Studio 15 2017
-    MEMCHECK: DRMEMORY
-    PLATFORM: amd64
-    CXX_STANDARD: 17
-
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build
-    BS: cmake
-    CMAKE_GENERATOR: Visual Studio 16 2019
-    MEMCHECK: DRMEMORY
-    PLATFORM: amd64
-    CXX_STANDARD: 14
-
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build
-    BS: cmake
-    CMAKE_GENERATOR: Visual Studio 16 2019
-    MEMCHECK: DRMEMORY
-    PLATFORM: amd64
-    CXX_STANDARD: 17
-
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build
-    BS: cmake
-    CMAKE_GENERATOR: Visual Studio 16 2019
-    MEMCHECK: DRMEMORY
-    PLATFORM: amd64
-    CXX_STANDARD: 20
-
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
-    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Auxiliary\Build
-    BS: cmake
-    CMAKE_GENERATOR: Visual Studio 16 2019
-    MEMCHECK: DRMEMORY
-    PLATFORM: amd64
-    CXX_STANDARD: 14
-
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
-    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Auxiliary\Build
-    BS: cmake
-    CMAKE_GENERATOR: Visual Studio 16 2019
-    MEMCHECK: DRMEMORY
-    PLATFORM: amd64
-    CXX_STANDARD: 17
-
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
-    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Auxiliary\Build
-    BS: cmake
-    CMAKE_GENERATOR: Visual Studio 16 2019
-    MEMCHECK: DRMEMORY
-    PLATFORM: amd64
-    CXX_STANDARD: 20
 
 matrix:
   fast_finish: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,22 +45,6 @@ environment:
     PLATFORM: amd64
     CXX_STANDARD: 17
 
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017 Preview
-    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\Preview\Community\VC\Auxiliary\Build
-    BS: cmake
-    CMAKE_GENERATOR: Visual Studio 15 2017
-    MEMCHECK: DRMEMORY
-    PLATFORM: amd64
-    CXX_STANDARD: 14
-
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017 Preview
-    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\Preview\Community\VC\Auxiliary\Build
-    BS: cmake
-    CMAKE_GENERATOR: Visual Studio 15 2017
-    MEMCHECK: DRMEMORY
-    PLATFORM: amd64
-    CXX_STANDARD: 17
-
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build
     BS: cmake
@@ -77,38 +61,37 @@ environment:
     PLATFORM: amd64
     CXX_STANDARD: 17
 
-  # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-  #   VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build
-  #   BS: cmake
-  #   CMAKE_GENERATOR: Visual Studio 16 2019
-  #   MEMCHECK: DRMEMORY
-  #   PLATFORM: amd64
-  #   CXX_STANDARD: 20
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build
+    BS: cmake
+    CMAKE_GENERATOR: Visual Studio 16 2019
+    MEMCHECK: DRMEMORY
+    PLATFORM: amd64
+    CXX_STANDARD: 20
 
-  # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
-  #   VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Auxiliary\Build
-  #   BS: cmake
-  #   CMAKE_GENERATOR: Visual Studio 16 2019
-  #   MEMCHECK: DRMEMORY
-  #   PLATFORM: amd64
-  #   CXX_STANDARD: 14
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
+    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Auxiliary\Build
+    BS: cmake
+    CMAKE_GENERATOR: Visual Studio 16 2019
+    MEMCHECK: DRMEMORY
+    PLATFORM: amd64
+    CXX_STANDARD: 14
 
-  # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
-  #   VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Auxiliary\Build
-  #   BS: cmake
-  #   CMAKE_GENERATOR: Visual Studio 16 2019
-  #   MEMCHECK: DRMEMORY
-  #   PLATFORM: amd64
-  #   CXX_STANDARD: 17
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
+    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Auxiliary\Build
+    BS: cmake
+    CMAKE_GENERATOR: Visual Studio 16 2019
+    MEMCHECK: DRMEMORY
+    PLATFORM: amd64
+    CXX_STANDARD: 17
 
-  # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
-  #   VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Auxiliary\Build
-  #   BS: cmake
-  #   CMAKE_GENERATOR: Visual Studio 16 2019
-  #   MEMCHECK: DRMEMORY
-  #   PLATFORM: amd64
-  #   CXX_STANDARD: 20
-
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
+    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Auxiliary\Build
+    BS: cmake
+    CMAKE_GENERATOR: Visual Studio 16 2019
+    MEMCHECK: DRMEMORY
+    PLATFORM: amd64
+    CXX_STANDARD: 20
 
 matrix:
   fast_finish: true

--- a/example/pool_provider.cpp
+++ b/example/pool_provider.cpp
@@ -85,7 +85,7 @@ struct pool_provider {
            ,
            const TMemory&  // stack/heap
            ,
-           TArgs&&... args) const {
+           TArgs&&... args) const -> std::unique_ptr<T, pool_deleter> {
     auto memory = pool_allocator::allocate<T>();
     return std::unique_ptr<T, pool_deleter>{new (memory) T(std::forward<TArgs>(args)...)};
   }
@@ -115,6 +115,8 @@ int main() {
   );
   // clang-format on
 
+  (void)injector;
+
   /*<<create `example` using configuration with `pool_provider`>>*/
-  injector.create<example>();
+ // injector.create<example>();
 }

--- a/extension/include/boost/di/extension/injections/factory.hpp
+++ b/extension/include/boost/di/extension/injections/factory.hpp
@@ -49,7 +49,8 @@ struct factory_impl<TInjector, T, ifactory<I, TArgs...>> : ifactory<I, TArgs...>
 template <class T>
 struct factory {
   template <class TInjector, class TDependency>
-  auto operator()(const TInjector& injector, const TDependency&) const {
+  auto operator()(const TInjector& injector, const TDependency&) const
+      -> std::shared_ptr<factory_impl<TInjector, T, typename TDependency::expected>> {
     static auto sp = std::make_shared<factory_impl<TInjector, T, typename TDependency::expected>>(injector);
     return sp;
   }

--- a/extension/include/boost/di/extension/injections/xml_injection.hpp
+++ b/extension/include/boost/di/extension/injections/xml_injection.hpp
@@ -27,7 +27,7 @@ template <class... TImpl>
 class inject_from_xml {
  public:
   template <class TInjector, class T>
-  auto operator()(const TInjector& injector, const T&) const {
+  auto operator()(const TInjector& injector, const T&) const -> std::shared_ptr<typename T::expected> {
     auto parser = injector.template create<std::unique_ptr<ixml_parser>>();
     auto parsed = parser->parse(typeid(typename T::expected).name());
     return create_impl<typename T::expected>(injector, parsed, xml_list<TImpl...>{});

--- a/extension/test/bindings/contextual_bindings.cpp
+++ b/extension/test/bindings/contextual_bindings.cpp
@@ -33,7 +33,7 @@ int main() {
   // clang-format off
   auto injector = di::make_injector<di::extension::contextual_bindings>(
       di::bind<>().to(123.f)
-    , di::bind<int>().to([](const auto& injector) {
+    , di::bind<int>().to([](const auto& injector) -> int {
         if (di::extension::context(injector) == "example->data") return 87;
         if (di::extension::context(injector) == "example->data->more_data") return 99;
         return 42;

--- a/test/ft/di_bind.cpp
+++ b/test/ft/di_bind.cpp
@@ -387,7 +387,7 @@ test scopes_instance_lambda_injector = [] {
 test scopes_instance_lambda_injector_mix = [] {
   auto injector = di::make_injector(
       di::bind<short>().to([] { return 42; }), di::bind<long>().to(87l),
-      di::bind<int>().to([](const auto &injector) { return static_cast<int>(injector.template create<long>()); }));
+      di::bind<int>().to([](const auto &injector) -> int { return static_cast<int>(injector.template create<long>()); }));
 
   expect(42 == injector.create<short>());
   expect(87 == injector.create<int>());
@@ -596,7 +596,7 @@ test runtime_factory_call_operator_impl = [] {
 
 test scopes_injector_lambda_injector = [] {
   constexpr double d = 42.0;
-  auto injector = di::make_injector(di::bind<double>().to(d), di::bind<int>().to([](const auto &injector) {
+  auto injector = di::make_injector(di::bind<double>().to(d), di::bind<int>().to([](const auto &injector) -> int {
     return static_cast<int>(injector.template create<double>());
   }));
 
@@ -1297,7 +1297,7 @@ test bind_to_ctor_ambigious_ctor = [] {
 test bind_to_ctor_ambigious_ctor_1_arg = [] {
   struct c {
     c(int a) : a(a) {}
-    c(double a) : a(a) {}
+    c(double a) : a(int(a)) {}
     int a{};
   };
 
@@ -1315,7 +1315,7 @@ test bind_to_ctor_ambigious_ctor_1_arg = [] {
 test bind_to_ctor_ambigious_ctor_1_arg_explicit = [] {
   struct c {
     explicit c(int a) : a(a) {}
-    explicit c(double a) : a(a) {}
+    explicit c(double a) : a(int(a)) {}
     int a{};
   };
 

--- a/test/ft/di_errors.cpp
+++ b/test/ft/di_errors.cpp
@@ -765,7 +765,7 @@ test not_configurable_config = [] {
 
 test make_policies_with_non_const_policy = [] {
   auto errors_ = errors("constraint not satisfied",
-#if defined(__MSVC__) && _MSC_VER < 1912
+#if defined(__MSVC__) //&& _MSC_VER < 1912
                         "policy<.*>::requires_<.*call_operator_with_one_argument>", "=.*non_const_policy"
 #else
                         "policy<.*non_const_policy>::requires_<.*call_operator_with_one_argument>"
@@ -802,7 +802,7 @@ test make_policies_with_non_movable_policy = [] {
 
 test config_wrong_policy = [] {
   auto errors_ = errors("constraint not satisfied",
-#if defined(__MSVC__) && _MSC_VER < 1912
+#if defined(__MSVC__) //&& _MSC_VER < 1912
                         "policy<.*>::requires_<.*call_operator_with_one_argument>", "=.*int"
 #else
                         "policy<.*int>::requires_<.*call_operator_with_one_argument>"
@@ -822,7 +822,7 @@ int main() { di::make_injector<test_config>(); }
 
     test config_policy_not_callable = [] {
       auto errors_ = errors("constraint not satisfied",
-#if defined(__MSVC__) && _MSC_VER < 1912
+#if defined(__MSVC__) //&& _MSC_VER < 1912
                             "policy<.*>::requires_<.*call_operator_with_one_argument>", "=.*dummy"
 #else
                             "policy<.*dummy>::requires_<.*call_operator_with_one_argument>"


### PR DESCRIPTION
…compiler

Problem:
- MSVC-16.5.4 is the newest version of Microsoft compiler but it's not enabled in Appveyor.

Solution:
- Fix compiler issues with `auto return type and lambda expressions` by explicitly specify the return type.
- Enable MSVC Preview in Appveyor.

Reviewers:
@kanstantsin-chernik 