### PR TITLE
:art: :bug: :wrench: [DI] Fix compilation issues with GCC-7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -244,7 +244,7 @@ script:
   - if [ "${TRAVIS_PULL_REQUEST}" == "false" ] && [ "${TRAVIS_BRANCH}" == "cpp14" ] && [ "${DOCUMENTATION}" != "" ]; then (
     pip install mkdocs -U --user && git clone https://github.com/boost-ext/di
     && cd di && rm -rf * && git checkout -b gh-pages -t origin/gh-pages && git reset --hard && rm -rf * && cd ..
-    && MKDOCS_THEME=boost-ext MKDOCS_SITE=site make doc
+    && MKDOCS_THEME=boost-modern MKDOCS_SITE=site make doc
     && MKDOCS_THEME=boost-classic MKDOCS_SITE=site/boost make doc readme
     && mv site/* di && cd di && git add -A . && git commit -am "doc update"
     && git push --force --quiet "https://${GH_TOKEN}@github.com/boost-ext/di"); fi

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -33,17 +33,17 @@ git clone https://github.com/boost-ext/di && cd di && make
 
 * [Clang-3.4+](https://travis-ci.org/boost-ext/di)
 * [GCC-5.2+](https://travis-ci.org/boost-ext/di)
-* [MSVC-2015+](https://ci.appveyor.com/project/krzysztof-jusiak/di)
+* [MSVC-2015+](https://ci.appveyor.com/project/boost-ext/di)
 
 ### Configuration
 | Macro                             | Description |
 | --------------------------------- | ----------- |
-| `BOOST_DI_VERSION`                | Current version of [Boost].DI (ex. 1'0'0) |
+| `BOOST_DI_VERSION`                | Current version of [Boost::ext].DI (ex. 1'0'0) |
 | `BOOST_DI_CFG`                    | Global configuration allows to customize provider and policies (See [Config](user_guide.md#di_config)) |
 | `BOOST_DI_CFG_CTOR_LIMIT_SIZE`    | Limits number of allowed constructor parameters [0-10, default=10] (See [Injections](user_guide.md#injections)) |
 | `BOOST_DI_CFG_DIAGNOSTICS_LEVEL`  | Gives more information with error messages (See [Error messages](#error-messages)) |
-| `BOOST_DI_NAMESPACE_BEGIN`        | `namespace boost { namespace di { inline namespace v_1_0_0 {` |
-| `BOOST_DI_NAMESPACE_END`          | `}}}` |
+| `BOOST_DI_NAMESPACE_BEGIN`        | `namespace boost::inline ext::di::inline v_{version}_{revision}_{patch} {` |
+| `BOOST_DI_NAMESPACE_END`          | `}` |
 
 ### Exception Safety
 

--- a/example/constructor_injection.cpp
+++ b/example/constructor_injection.cpp
@@ -39,6 +39,7 @@ struct ctor_di_traits {
 };
 
 namespace boost {
+inline namespace ext {
 namespace di {
 
 template <>
@@ -48,6 +49,7 @@ struct ctor_traits<ctor_di_traits> {
 };
 
 }  // namespace di
+}  // namespace ext
 }  // namespace boost
 
 struct ctor_inject_traits_no_limits {

--- a/example/user_guide/annotated_constructor_injection_with_ctor_traits.cpp
+++ b/example/user_guide/annotated_constructor_injection_with_ctor_traits.cpp
@@ -21,12 +21,14 @@ struct T {
 };
 
 namespace boost {
+inline namespace ext {
 namespace di {
 template <>
 struct ctor_traits<T> {
   BOOST_DI_INJECT_TRAITS((named = int1) int, (named = int2) int);
 };
 }  // namespace di
+}  // namespace ext
 }  // namespace boost
 
 int main() {

--- a/example/user_guide/constructor_injection_ambiguous_constructors_via_ctor_traits.cpp
+++ b/example/user_guide/constructor_injection_ambiguous_constructors_via_ctor_traits.cpp
@@ -20,12 +20,14 @@ struct T {
 };
 
 namespace boost {
+inline namespace ext {
 namespace di {
 template <>
 struct ctor_traits<T> {
   BOOST_DI_INJECT_TRAITS(int, double);
 };
 }  // namespace di
+}  // namespace ext
 }  // namespace boost
 
 int main() {

--- a/test/ft/di_inject.cpp
+++ b/test/ft/di_inject.cpp
@@ -74,6 +74,7 @@ struct c_no_limits {
 };
 
 namespace boost {
+inline namespace ext {
 namespace di {
 
 template <>
@@ -81,6 +82,7 @@ struct ctor_traits<c_no_limits> {
   using boost_di_inject__ = di::inject<int, int, int, int, int, int, int, int, int, int, int>;
 };
 }  // namespace di
+}  // namespace ext
 }  // namespace boost
 
 test inject_traits_no_limits_via_ctor_traits = [] {


### PR DESCRIPTION
Problem:
- GCC-7 complains about ambiguous namespaces due to `inline ext` namespace.

Solution:
- Put `inline ext` namespace explicitly instead.