### PR TITLE
:fire: :wrench: [appveyor] Remove MSVC-2017 Preview images

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,22 +45,6 @@ environment:
     PLATFORM: amd64
     CXX_STANDARD: 17
 
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017 Preview
-    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\Preview\Community\VC\Auxiliary\Build
-    BS: cmake
-    CMAKE_GENERATOR: Visual Studio 15 2017
-    MEMCHECK: DRMEMORY
-    PLATFORM: amd64
-    CXX_STANDARD: 14
-
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017 Preview
-    VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\Preview\Community\VC\Auxiliary\Build
-    BS: cmake
-    CMAKE_GENERATOR: Visual Studio 15 2017
-    MEMCHECK: DRMEMORY
-    PLATFORM: amd64
-    CXX_STANDARD: 17
-
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     VSPATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build
     BS: cmake


### PR DESCRIPTION
Problem:
- MSVC-2017 Preview image is not available anymore.

Solution:
- Remove if from the matrix.