### PR TITLE
:wrench: :arrow_up: [MSVC-2019] Wknd issues with MSVC

### DIFF
--- a/extension/include/boost/di/extension/injections/factory.hpp
+++ b/extension/include/boost/di/extension/injections/factory.hpp
@@ -49,7 +49,8 @@ struct factory_impl<TInjector, T, ifactory<I, TArgs...>> : ifactory<I, TArgs...>
 template <class T>
 struct factory {
   template <class TInjector, class TDependency>
-  auto operator()(const TInjector& injector, const TDependency&) const {
+  auto operator()(const TInjector& injector, const TDependency&) const
+      -> std::shared_ptr<factory_impl<TInjector, T, typename TDependency::expected>> {
     static auto sp = std::make_shared<factory_impl<TInjector, T, typename TDependency::expected>>(injector);
     return sp;
   }

--- a/extension/include/boost/di/extension/injections/xml_injection.hpp
+++ b/extension/include/boost/di/extension/injections/xml_injection.hpp
@@ -27,7 +27,7 @@ template <class... TImpl>
 class inject_from_xml {
  public:
   template <class TInjector, class T>
-  auto operator()(const TInjector& injector, const T&) const {
+  auto operator()(const TInjector& injector, const T&) const -> std::shared_ptr<typename T::expected> {
     auto parser = injector.template create<std::unique_ptr<ixml_parser>>();
     auto parsed = parser->parse(typeid(typename T::expected).name());
     return create_impl<typename T::expected>(injector, parsed, xml_list<TImpl...>{});

--- a/extension/test/bindings/contextual_bindings.cpp
+++ b/extension/test/bindings/contextual_bindings.cpp
@@ -33,7 +33,7 @@ int main() {
   // clang-format off
   auto injector = di::make_injector<di::extension::contextual_bindings>(
       di::bind<>().to(123.f)
-    , di::bind<int>().to([](const auto& injector) {
+    , di::bind<int>().to([](const auto& injector) -> int{
         if (di::extension::context(injector) == "example->data") return 87;
         if (di::extension::context(injector) == "example->data->more_data") return 99;
         return 42;

--- a/test/ft/di_bind.cpp
+++ b/test/ft/di_bind.cpp
@@ -387,7 +387,7 @@ test scopes_instance_lambda_injector = [] {
 test scopes_instance_lambda_injector_mix = [] {
   auto injector = di::make_injector(
       di::bind<short>().to([] { return 42; }), di::bind<long>().to(87l),
-      di::bind<int>().to([](const auto &injector) { return static_cast<int>(injector.template create<long>()); }));
+      di::bind<int>().to([](const auto &injector) -> int { return static_cast<int>(injector.template create<long>()); }));
 
   expect(42 == injector.create<short>());
   expect(87 == injector.create<int>());
@@ -596,7 +596,7 @@ test runtime_factory_call_operator_impl = [] {
 
 test scopes_injector_lambda_injector = [] {
   constexpr double d = 42.0;
-  auto injector = di::make_injector(di::bind<double>().to(d), di::bind<int>().to([](const auto &injector) {
+  auto injector = di::make_injector(di::bind<double>().to(d), di::bind<int>().to([](const auto &injector) -> int {
     return static_cast<int>(injector.template create<double>());
   }));
 
@@ -1297,7 +1297,7 @@ test bind_to_ctor_ambigious_ctor = [] {
 test bind_to_ctor_ambigious_ctor_1_arg = [] {
   struct c {
     c(int a) : a(a) {}
-    c(double a) : a(a) {}
+    c(double a) : a(int(a)) {}
     int a{};
   };
 
@@ -1315,7 +1315,7 @@ test bind_to_ctor_ambigious_ctor_1_arg = [] {
 test bind_to_ctor_ambigious_ctor_1_arg_explicit = [] {
   struct c {
     explicit c(int a) : a(a) {}
-    explicit c(double a) : a(a) {}
+    explicit c(double a) : a(int(a)) {}
     int a{};
   };
 


### PR DESCRIPTION
Problem:
- `MSVC-2019` seem to have problems with deducing a type from a lambda expression with injected injector.

Solution:
- Explicitly set the return type for such lambdas.