### PR TITLE
:wrench: :arrow_up: [travis] Update matrix with the newest compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,20 @@ matrix:
           - gdb
 
   - os: linux
+    dist: bionic
+    env: BS=cmake CXX=clang++-10 LBCXX=ON
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - sourceline: 'deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
+            key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+        packages:
+          - clang-10
+          - libstdc++-10-dev
+          - valgrind
+
+  - os: linux
     dist: trusty
     env: BS=cmake CXX=g++-5
     addons: { apt: { packages: ["g++-5", "libstdc++-5-dev", "gdb"], sources: ["ubuntu-toolchain-r-test"] } }
@@ -131,6 +145,23 @@ matrix:
     env: BS=cmake CXX=g++-8
     addons: { apt: { packages: ["g++-8", "libstdc++-8-dev", "gdb"], sources: ["ubuntu-toolchain-r-test"] } }
 
+  - os: linux
+    dist: trusty
+    env: BS=cmake CXX=g++-9
+    addons: { apt: { packages: ["g++-9", "libstdc++-9-dev", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
+
+  - os: linux
+    dist: bionic
+    env: BS=cmake CXX=g++-10
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - g++-10
+          - valgrind
+          - libstdc++-10-dev
+
   - os: osx
     osx_image: xcode8.3
     env: BS=cmake CXX=clang++
@@ -144,7 +175,7 @@ matrix:
     env: BS=cmake CXX=clang++
 
   - os: osx
-    osx_image: xcode11
+    osx_image: xcode11.6
     env: BS=cmake CXX=clang++
 
 #
@@ -161,7 +192,7 @@ matrix:
     addons: { apt: { packages: ["g++-8", "libstdc++-8-dev", "gdb"], sources: ["ubuntu-toolchain-r-test"] } }
 
   - os: osx
-    osx_image: xcode11
+    osx_image: xcode11.6
     env: BS=bjam TOOLSET=clang CXX=clang++
 
 #
@@ -187,7 +218,7 @@ matrix:
     addons: { apt: { packages: ["g++-8", "libstdc++-8-dev", "gdb"], sources: ["ubuntu-toolchain-r-test"] } }
 
   - os: osx
-    osx_image: xcode11
+    osx_image: xcode11.6
     env: BS=cmake VARIANT=analyze CXX=clang++
 
 #
@@ -213,7 +244,7 @@ matrix:
     addons: { apt: { packages: ["g++-8", "libstdc++-8-dev", "valgrind", "gdb"], sources: ["ubuntu-toolchain-r-test"] } }
 
   - os: osx
-    osx_image: xcode11
+    osx_image: xcode11.6
     env: BS=cmake MEMCHECK=valgrind CXX=clang++
 
 #


### PR DESCRIPTION
Problem:
- Clang-10/GCC-9/GCC-10/xcode11.6 aren't included in the matrix.

Solution:
- Extend the matrix with the newest compilers.