### PR TITLE
[ABANDONED] Use std::integer_sequence for aux::make_index_sequence when available

### DIFF
--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -164,6 +164,9 @@ template <class>
 class shared_ptr;
 }
 #endif
+#if defined(__cpp_lib_integer_sequence)
+#include <utility>
+#endif
 BOOST_DI_NAMESPACE_BEGIN
 struct _ {
   _(...) {}
@@ -238,7 +241,7 @@ template <int...>
 struct index_sequence {
   using type = index_sequence;
 };
-#if defined(__cpp_lib_integer_sequence) && defined(__GNUC__)
+#if defined(__cpp_lib_integer_sequence)
 template <int... Ns>
 index_sequence<Ns...> from_std(std::integer_sequence<int, Ns...>) {
   return {};

--- a/include/boost/di/aux_/utility.hpp
+++ b/include/boost/di/aux_/utility.hpp
@@ -7,6 +7,10 @@
 #ifndef BOOST_DI_AUX_UTILITY_HPP
 #define BOOST_DI_AUX_UTILITY_HPP
 
+#if defined(__cpp_lib_integer_sequence)
+#include <utility>
+#endif
+
 struct _ {
   _(...) {}
 };
@@ -102,7 +106,7 @@ struct index_sequence {
   using type = index_sequence;
 };
 
-#if defined(__cpp_lib_integer_sequence) && defined(__GNUC__)  // __pph__
+#if defined(__cpp_lib_integer_sequence)  // __pph__
 template <int... Ns>
 index_sequence<Ns...> from_std(std::integer_sequence<int, Ns...>) {
   return {};

--- a/include/boost/di/fwd_ext.hpp
+++ b/include/boost/di/fwd_ext.hpp
@@ -102,6 +102,10 @@ class shared_ptr;
 }  // namespace boost
 #endif                           // __pph__
 
+#if defined(__cpp_lib_integer_sequence)  // __pph__
+#include <utility>                       // __pph__
+#endif                                   // __pph__
+
 #undef NAMESPACE_STD_BEGIN  // __pph__
 #undef NAMESPACE_STD_END    // __pph__
 


### PR DESCRIPTION
Problem:
- BOOST_DI_CFG_CTOR_LIMIT_SIZE currently doesn't work on Visual Studio

Solution:
- Use #426's approach

BOOST_DI_CFG_CTOR_LIMIT_SIZE currently doesn't work on Visual Studio. The same
problem was raised in #271 and #273, and resolved in #426, but for unknown
reasons, the solution was applied only to GCC. The #426's approach is very
intuitive and concise than other methods, and works well with most modern
compilers other than GCC. This PR suggests using the #426's approach to resolve
BOOST_DI_CFG_CTOR_LIMIT_SIZE problems whenever available.

Issue: #271, #273

Reviewers: @krzysztof-jusiak 