### PR TITLE
:bug: [utility] Unified support for constructors with more than 10 ar…

### DIFF
--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -238,19 +238,9 @@ template <int...>
 struct index_sequence {
   using type = index_sequence;
 };
-#if defined(__cpp_lib_integer_sequence) && defined(__GNUC__)
-template <int... Ns>
-index_sequence<Ns...> from_std(std::integer_sequence<int, Ns...>) {
-  return {};
-}
-template <int N>
-using make_index_sequence = decltype(from_std(std::make_integer_sequence<int, N>{}));
-#else
 #if __has_builtin(__make_integer_seq)
-template <class T, T...>
-struct integer_sequence;
-template <int... Ns>
-struct integer_sequence<int, Ns...> {
+template <class T, T... Ns>
+struct integer_sequence {
   using type = index_sequence<Ns...>;
 };
 template <int N>
@@ -258,8 +248,17 @@ struct make_index_sequence_impl {
   using type = typename __make_integer_seq<integer_sequence, int, N>::type;
 };
 #else
-template <int>
-struct make_index_sequence_impl;
+template <class...>
+struct build_index_sequence;
+template <int... Cs1, int... Cs2>
+struct build_index_sequence<index_sequence<Cs1...>, index_sequence<Cs2...>> {
+  using type = index_sequence<Cs1..., sizeof...(Cs1) + Cs1..., 2 * sizeof...(Cs1) + Cs2...>;
+};
+template <int N>
+struct make_index_sequence_impl {
+  using type = typename build_index_sequence<typename make_index_sequence_impl<N / 2>::type,
+                                             typename make_index_sequence_impl<N % 2>::type>::type;
+};
 template <>
 struct make_index_sequence_impl<0> : index_sequence<> {};
 template <>
@@ -285,7 +284,6 @@ struct make_index_sequence_impl<10> : index_sequence<0, 1, 2, 3, 4, 5, 6, 7, 8, 
 #endif
 template <int N>
 using make_index_sequence = typename make_index_sequence_impl<N>::type;
-#endif
 }
 namespace placeholders {
 __BOOST_DI_UNUSED static const struct arg { } _{}; }

--- a/include/boost/di/aux_/utility.hpp
+++ b/include/boost/di/aux_/utility.hpp
@@ -102,67 +102,54 @@ struct index_sequence {
   using type = index_sequence;
 };
 
-#if defined(__cpp_lib_integer_sequence) && defined(__GNUC__)  // __pph__
-template <int... Ns>
-index_sequence<Ns...> from_std(std::integer_sequence<int, Ns...>) {
-  return {};
-}
-template <int N>
-using make_index_sequence = decltype(from_std(std::make_integer_sequence<int, N>{}));
-#else                                  // __pph__
 #if __has_builtin(__make_integer_seq)  // __pph__
-template <class T, T...>
-struct integer_sequence;
-template <int... Ns>
-struct integer_sequence<int, Ns...> {
+template <class T, T... Ns>
+struct integer_sequence {
   using type = index_sequence<Ns...>;
 };
 template <int N>
 struct make_index_sequence_impl {
   using type = typename __make_integer_seq<integer_sequence, int, N>::type;
 };
-#else                                  // __pph__
-template <int>
-struct make_index_sequence_impl;
+#else   // __pph__
+template <class...>
+struct build_index_sequence;
+template <int... Cs1, int... Cs2>
+struct build_index_sequence<index_sequence<Cs1...>, index_sequence<Cs2...>> {
+  using type = index_sequence<Cs1..., sizeof...(Cs1) + Cs1..., 2 * sizeof...(Cs1) + Cs2...>;
+};
 
+template <int N>
+struct make_index_sequence_impl {
+  using type = typename build_index_sequence<typename make_index_sequence_impl<N / 2>::type,
+                                             typename make_index_sequence_impl<N % 2>::type>::type;
+};
 template <>
 struct make_index_sequence_impl<0> : index_sequence<> {};
-
 template <>
 struct make_index_sequence_impl<1> : index_sequence<0> {};
-
 template <>
 struct make_index_sequence_impl<2> : index_sequence<0, 1> {};
-
 template <>
 struct make_index_sequence_impl<3> : index_sequence<0, 1, 2> {};
-
 template <>
 struct make_index_sequence_impl<4> : index_sequence<0, 1, 2, 3> {};
-
 template <>
 struct make_index_sequence_impl<5> : index_sequence<0, 1, 2, 3, 4> {};
-
 template <>
 struct make_index_sequence_impl<6> : index_sequence<0, 1, 2, 3, 4, 5> {};
-
 template <>
 struct make_index_sequence_impl<7> : index_sequence<0, 1, 2, 3, 4, 5, 6> {};
-
 template <>
 struct make_index_sequence_impl<8> : index_sequence<0, 1, 2, 3, 4, 5, 6, 7> {};
-
 template <>
 struct make_index_sequence_impl<9> : index_sequence<0, 1, 2, 3, 4, 5, 6, 7, 8> {};
-
 template <>
 struct make_index_sequence_impl<10> : index_sequence<0, 1, 2, 3, 4, 5, 6, 7, 8, 9> {};
 #endif  // __pph__
 
 template <int N>
 using make_index_sequence = typename make_index_sequence_impl<N>::type;
-#endif  // __pph__
-
 }  // namespace aux
 
 #endif

--- a/test/ut/aux_/utility.cpp
+++ b/test/ut/aux_/utility.cpp
@@ -21,6 +21,9 @@ test index_sequence_types = [] {
   static_expect(std::is_same<index_sequence<0, 1, 2, 3, 4, 5, 6, 7>, make_index_sequence<8>>::value);
   static_expect(std::is_same<index_sequence<0, 1, 2, 3, 4, 5, 6, 7, 8>, make_index_sequence<9>>::value);
   static_expect(std::is_same<index_sequence<0, 1, 2, 3, 4, 5, 6, 7, 8, 9>, make_index_sequence<10>>::value);
+  static_expect(std::is_same<index_sequence<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10>, make_index_sequence<11>>::value);
+  static_expect(
+      std::is_same<index_sequence<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15>, make_index_sequence<16>>::value);
 };
 
 test join_types = [] {


### PR DESCRIPTION
…guments

Problem:
- `aux::index_sequence` only supports up to 10 parameters when `__make_integer_seq` is not available.

Solution:
- Extend support for `aux::make_index_sequence` to an arbitrary number of parameters.
