### PR TITLE
Use declval instead of null casts

### DIFF
--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -3045,7 +3045,7 @@ template <class TConfig = BOOST_DI_CFG, class... TDeps,
           __BOOST_DI_REQUIRES_MSG(concepts::configurable<TConfig>) = 0>
 inline auto make_injector(TDeps... args) noexcept {
   return __BOOST_DI_MAKE_INJECTOR(
-      core::injector<TConfig, decltype(((TConfig*)0)->policies((concepts::injector<TConfig>*)0)), TDeps...>{
+      core::injector<TConfig, decltype(aux::declval<TConfig>().policies(aux::declval<concepts::injector<TConfig>*>())), TDeps...>{
           core::init{}, static_cast<TDeps&&>(args)...});
 }
 namespace policies {


### PR DESCRIPTION
Problem:
- Fix null cast warning in GCC 11

Solution:
- Replace cast with  `aux::declval`

Issue: #521 

Reviewers:
@