### PR TITLE
:bug: :wrench: [DI] Fix injection with placeholder.

### DIFF
--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -2897,7 +2897,7 @@ class injector<TConfig, pool<>, TDeps...> : public injector_base, public pool<bi
   }
   template <class TIsRoot = aux::false_type, class TParent, int N>
   auto create_successful_impl(const aux::type<core::ctor_arg<TParent, N, const placeholders::arg&>>&) const {
-    return any_type_1st_ref<TParent, injector, aux::false_type, aux::true_type>{*this};
+    return successful::any_type_1st_ref<TParent, injector>{*this};
   }
   template <class TIsRoot = aux::false_type, class T>
   decltype(auto) create_successful_impl(const aux::type<self<T>>&) const {

--- a/test/ft/di_bind.cpp
+++ b/test/ft/di_bind.cpp
@@ -1385,6 +1385,34 @@ test bind_to_ctor_multiple_placeholders = [] {
   expect(dynamic_cast<impl2 *>(object.c_.up.get()));
 };
 
+
+test bind_to_const_ref_sharedptr_via_placeholder = [] {
+  struct i {
+    virtual ~i() noexcept = default;
+    virtual int get_value() = 0;
+  };
+
+  struct impl : i {
+    int get_value() override { return 5; }
+  };
+
+  struct app {
+    explicit app(const std::shared_ptr<i>& p)
+    : value {p->get_value()}
+    {}
+    int value;
+  };
+
+  const auto injector = di::make_injector(
+     di::bind<i>().to<impl>(),
+     di::bind<app>(di::placeholders::_)
+    );
+
+  auto object = injector.create<app>();
+
+  expect(5 == object.value);
+};
+
 test bind_to_ctor_short_notation = [] {
   struct c {
     c(int a, int b) : a{a}, b{b} {}


### PR DESCRIPTION
Problem:
- A const reference to a shared_ptr injected via placeholder causing reference to temporary warning and segfault when accessing the value.

Solution:
- Use `successful::any_type_1st_ref` instead of `any_type_1st_ref` in `create_successful_impl`.

Issue: #532

Reviewers:
@kris-jusiak 