### PR TITLE
Replace instances of nullptr dereferencing in unevaluated contexts wi…

### DIFF
--- a/extension/include/boost/di/extension/providers/mocks_provider.hpp
+++ b/extension/include/boost/di/extension/providers/mocks_provider.hpp
@@ -64,7 +64,7 @@ class mocks_provider : public config {
     static std::true_type resolve_impl(TKey*);
 
     template <class TKey, class T>
-    struct resolve : decltype(resolve_impl<TKey>((T*)0)) {};
+    struct resolve : decltype(resolve_impl<TKey>(aux::declval<T*>())) {};
 
     template <class>
     struct transform;

--- a/include/boost/di/aux_/type_traits.hpp
+++ b/include/boost/di/aux_/type_traits.hpp
@@ -382,7 +382,7 @@ aux::false_type is_callable_impl(T*, aux::non_type<void (callable_base_impl::*)(
 aux::true_type is_callable_impl(...);
 
 template <class T>
-struct is_callable : decltype(is_callable_impl((callable_base<T>*)0)) {};
+struct is_callable : decltype(is_callable_impl(aux::declval<callable_base<T>*>())) {};
 
 template <class, class = int>
 struct is_empty_expr : false_type {};

--- a/include/boost/di/concepts/configurable.hpp
+++ b/include/boost/di/concepts/configurable.hpp
@@ -35,8 +35,8 @@ struct injector {
 aux::false_type configurable_impl(...);
 
 template <class T>
-auto configurable_impl(T &&) -> aux::is_valid_expr<decltype(aux::declval<T>().provider((injector<T>*)0)),
-                                                   decltype(aux::declval<T>().policies((injector<T>*)0))>;
+auto configurable_impl(T &&) -> aux::is_valid_expr<decltype(aux::declval<T>().provider(aux::declval<injector<T>*>())),
+                                                   decltype(aux::declval<T>().policies(aux::declval<injector<T>*>()))>;
 
 template <class T1, class T2>
 struct get_configurable_error : aux::type_list<T1, T2> {};
@@ -56,8 +56,8 @@ struct get_configurable_error<aux::true_type, aux::true_type> : aux::true_type {
 
 template <class T>
 auto is_configurable(const aux::true_type&) {
-  return typename get_configurable_error<decltype(providable<decltype(aux::declval<T>().provider((injector<T>*)0))>()),
-                                         decltype(callable<decltype(aux::declval<T>().policies((injector<T>*)0))>())>::type{};
+  return typename get_configurable_error<decltype(providable<decltype(aux::declval<T>().provider(aux::declval<injector<T>*>()))>()),
+                                         decltype(callable<decltype(aux::declval<T>().policies(aux::declval<injector<T>*>()))>())>::type{};
 }
 
 template <class T>

--- a/include/boost/di/core/binder.hpp
+++ b/include/boost/di/core/binder.hpp
@@ -45,7 +45,7 @@ struct binder {
 
   template <class TDeps, class T, class TName, class TDefault>
   struct resolve__ {
-    using type = decltype(resolve_impl__<TDefault, dependency_concept<aux::decay_t<T>, TName>>((TDeps*)0));
+    using type = decltype(resolve_impl__<TDefault, dependency_concept<aux::decay_t<T>, TName>>(aux::declval<TDeps*>()));
   };
 
 /// Wknd for https://llvm.org/bugs/show_bug.cgi?id=28844
@@ -79,7 +79,7 @@ struct binder {
 
 /// Wknd for https://llvm.org/bugs/show_bug.cgi?id=28844
 #if (defined(__CLANG__) && __CLANG__ >= 3'9)  // __pph__
-    return resolve_(deps, aux::type<decltype(resolve_impl<TDefault, dependency>((TDeps*)0))>{});
+    return resolve_(deps, aux::type<decltype(resolve_impl<TDefault, dependency>(aux::declval<TDeps*>()))>{});
 #else   // __pph__
     return resolve_impl<TDefault, dependency>(deps);
 #endif  // __pph__

--- a/include/boost/di/core/injector.hpp
+++ b/include/boost/di/core/injector.hpp
@@ -84,7 +84,7 @@ class injector __BOOST_DI_CORE_INJECTOR_POLICY()(<TConfig, pool<>, TDeps...>)
 
     static constexpr auto value =
         aux::is_convertible<decltype(dependency__<dependency_t>::template try_create<T, TName>(
-                                try_provider<ctor_t, injector, decltype(aux::declval<TConfig>().provider((injector*)0))>{})),
+                                try_provider<ctor_t, injector, decltype(aux::declval<TConfig>().provider(aux::declval<injector*>()))>{})),
                             T>::value
             __BOOST_DI_CORE_INJECTOR_POLICY(
                 &&policy::template try_call<arg_wrapper<T, TName, TIsRoot, ctor_args_t, dependency_t, pool_t>,

--- a/include/boost/di/core/policy.hpp
+++ b/include/boost/di/core/policy.hpp
@@ -29,7 +29,7 @@ struct arg_wrapper<T, TName, TIsRoot, TList<TCtor...>, TDependency, TDeps> {
   using is_root __BOOST_DI_UNUSED = TIsRoot;
 
   template <class T_, class TName_, class TDefault_>
-  using resolve = decltype(core::binder::resolve<T_, TName_, TDefault_>((TDeps*)0));
+  using resolve = decltype(core::binder::resolve<T_, TName_, TDefault_>(aux::declval<TDeps*>()));
 };
 
 template <class T>

--- a/include/boost/di/core/provider.hpp
+++ b/include/boost/di/core/provider.hpp
@@ -54,7 +54,7 @@ struct provider<aux::pair<T, aux::pair<TInitialization, TList<TCtor...>>>, TName
 
   template <class, class... TArgs>
   struct is_creatable {
-    using type = decltype(aux::declval<injector__<TInjector>>().cfg().provider((TInjector*)0));
+    using type = decltype(aux::declval<injector__<TInjector>>().cfg().provider(aux::declval<TInjector*>()));
     static constexpr auto value = type::template is_creatable<TInitialization, T, TArgs...>::value;
   };
 

--- a/include/boost/di/make_injector.hpp
+++ b/include/boost/di/make_injector.hpp
@@ -33,7 +33,7 @@ template <class TConfig = BOOST_DI_CFG, class... TDeps,
           __BOOST_DI_REQUIRES_MSG(concepts::configurable<TConfig>) = 0>
 inline auto make_injector(TDeps... args) noexcept {
   return __BOOST_DI_MAKE_INJECTOR(
-      core::injector<TConfig, decltype(((TConfig*)0)->policies((concepts::injector<TConfig>*)0)), TDeps...>{
+      core::injector<TConfig, decltype(aux::declval<TConfig*>()->policies(aux::declval<concepts::injector<TConfig>*>())), TDeps...>{
           core::init{}, static_cast<TDeps&&>(args)...});
 }
 #undef __BOOST_DI_MAKE_INJECTOR  // __pph__

--- a/test/ut/config.cpp
+++ b/test/ut/config.cpp
@@ -27,8 +27,8 @@ test make_policies_types = [] {
 };
 
 test default_config = [] {
-  expect(std::is_same<providers::stack_over_heap, decltype(std::declval<config>().provider((fake_injector<>*)0))>{});
-  expect(std::is_same<core::pool<aux::type_list<>>, decltype(std::declval<config>().policies((fake_injector<>*)0))>{});
+  expect(std::is_same<providers::stack_over_heap, decltype(std::declval<config>().provider(std::declval<fake_injector<>*>()))>{});
+  expect(std::is_same<core::pool<aux::type_list<>>, decltype(std::declval<config>().policies(std::declval<fake_injector<>*>()))>{});
 };
 
 struct c {};


### PR DESCRIPTION
…th declval

Problem:
-
Instances of nullptr dereferencing in unevaluated contexts error under [-Werror=nonnull].
Tested on C++20.

Solution:
-
Replace with `aux::declval` / `std::declval`.

Issue: #

Reviewers:
@