### PR TITLE
Modernized CMake, added Boost::headers dependency and install option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build*/
 site/
+.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,57 +4,71 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
-cmake_minimum_required(VERSION 2.8)
-project(Boost.DI CXX)
-set(CXX_STANDARD 14 CACHE STRING "C++ Standard Version. [14|17|20]")
+cmake_minimum_required(VERSION 3.13)
+project(Boost.DI LANGUAGES CXX)
+
+if(CMAKE_VERSION VERSION_LESS 3.21)
+    # Emulates CMake 3.21+ behavior.
+    if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+        set(PROJECT_IS_TOP_LEVEL ON)
+        set(${PROJECT_NAME}_IS_TOP_LEVEL ON)
+    else()
+        set(PROJECT_IS_TOP_LEVEL OFF)
+        set(${PROJECT_NAME}_IS_TOP_LEVEL OFF)
+    endif()
+endif()
+
+include(GNUInstallDirs)
+
+find_package(Boost REQUIRED COMPONENTS headers)
+
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 14)
+elseif(CMAKE_CXX_STANDARD LESS 14)
+    message(FATAL_ERROR "Boost.DI requires at least C++14")
+endif()
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(
-        ${PROJECT_NAME} INTERFACE
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/extension/include
+    ${PROJECT_NAME} INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/extension/include>
 )
+target_link_libraries(${PROJECT_NAME} INTERFACE Boost::headers)
 
-if(${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
-    set(COMPILER_SPECIFIC_CXX_STANDARD "-std=c++${CXX_STANDARD}")
-    string(REPLACE "14" "1y" COMPILER_SPECIFIC_CXX_STANDARD ${COMPILER_SPECIFIC_CXX_STANDARD})
-    string(REPLACE "17" "1z" COMPILER_SPECIFIC_CXX_STANDARD ${COMPILER_SPECIFIC_CXX_STANDARD})
-    string(REPLACE "20" "2a" COMPILER_SPECIFIC_CXX_STANDARD ${COMPILER_SPECIFIC_CXX_STANDARD})    
+option(BOOST_DI_OPT_BUILD_TESTS "Build and perform Boost.DI tests" ${PROJECT_IS_TOP_LEVEL})
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMPILER_SPECIFIC_CXX_STANDARD} -fno-exceptions -pedantic -pedantic-errors -Wall -Wextra -Werror")
-
-elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL Clang OR ${CMAKE_CXX_COMPILER_ID} STREQUAL AppleClang)
-    set(COMPILER_SPECIFIC_CXX_STANDARD "-std=c++${CXX_STANDARD}")
-    string(REPLACE "14" "1y" COMPILER_SPECIFIC_CXX_STANDARD ${COMPILER_SPECIFIC_CXX_STANDARD})
-    string(REPLACE "17" "1z" COMPILER_SPECIFIC_CXX_STANDARD ${COMPILER_SPECIFIC_CXX_STANDARD})
-    string(REPLACE "20" "2a" COMPILER_SPECIFIC_CXX_STANDARD ${COMPILER_SPECIFIC_CXX_STANDARD})    
-
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMPILER_SPECIFIC_CXX_STANDARD} -fno-exceptions -pedantic -pedantic-errors -Wall -Wextra -Werror")
-    
-elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
-    set(COMPILER_SPECIFIC_CXX_STANDARD "/std:c++${CXX_STANDARD}")
-    string(REPLACE "20" "latest" COMPILER_SPECIFIC_CXX_STANDARD ${COMPILER_SPECIFIC_CXX_STANDARD})
-
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMPILER_SPECIFIC_CXX_STANDARD} /W3 /EHsc /Zc:__cplusplus")
-
-else()
-    message(WARNING "Unsupported compiler!")
-endif()
-
-if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-    set(IS_TOPLEVEL_PROJECT TRUE)
-else ()
-    set(IS_TOPLEVEL_PROJECT FALSE)
-endif ()
-
-option(BOOST_DI_OPT_BUILD_TESTS "Build and perform Boost.DI tests" ${IS_TOPLEVEL_PROJECT})
-if (BOOST_DI_OPT_BUILD_TESTS)
+if(BOOST_DI_OPT_BUILD_TESTS)
     enable_testing()
     add_subdirectory(extension/test)
     add_subdirectory(test)
-endif ()
+endif()
 
-option(BOOST_DI_OPT_BUILD_EXAMPLES "Build perform Boost.DI examples" ${IS_TOPLEVEL_PROJECT})
-if (BOOST_DI_OPT_BUILD_EXAMPLES)
+option(BOOST_DI_OPT_BUILD_EXAMPLES "Build perform Boost.DI examples" ${PROJECT_IS_TOP_LEVEL})
+
+if(BOOST_DI_OPT_BUILD_EXAMPLES)
     add_subdirectory(example)
-endif ()
+endif()
+
+option(BOOST_DI_OPT_INSTALL "Install Boost.DI" "NOT ${PROJECT_IS_TOP_LEVEL}")
+
+if(BOOST_DI_OPT_INSTALL)
+    install(
+        TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Config
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+
+    install(
+        EXPORT ${PROJECT_NAME}Config
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+        NAMESPACE Boost::
+    )
+
+    install(
+        DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+endif()


### PR DESCRIPTION
- Added `Boost::headers` linkage with `INTERFACE` visibility. This is important because targets that link to DI needed to also link to the Boost headers manually, or use esoteric include directives. This way, CMake handles the main Boost headers dependency.
- Removed old `CXX_STANDARD` paradigms in favor of modern a approach.
- Added `BOOST_DI_OPT_INSTALL` to install DI headers.