### PR TITLE
clang-tidy: Remove deprecated AnalyzeTemporaryDtors option

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,6 @@
 ---
 Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-alpha*,*,-llvm-namespace-comment,-llvm-include-order,-readability-named-parameter,-google-readability-namespace-comments,-google-build-using-namespace,-google-readability-namespace-comments'
 HeaderFilterRegex: boost/di
-AnalyzeTemporaryDtors: false
 CheckOptions:
   - key:             google-readability-braces-around-statements.ShortStatementLines
     value:           '1'


### PR DESCRIPTION
Deprecated in clang-tidy 16, fully remove in clang-tidy 18.

Problem:
- When we upgrade to clang-tidy version 18, clang-tidy reports an error similar to this: "error: unknown key 'AnalyzeTemporaryDtors'"

Solution:
- Deprecated AnalyzeTemporaryDtors option removed