### PR TITLE
Extension option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,13 @@ elseif(CMAKE_CXX_STANDARD LESS 14)
     message(FATAL_ERROR "Boost.DI requires at least C++14")
 endif()
 
+option(BOOST_DI_OPT_EXTENSION "Enable Boost.DI extensions" ON)
+
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(
     ${PROJECT_NAME} INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/extension/include>
+    $<$<BOOL:${USE_EXTENSION}>:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/extension/include>>
 )
 option(BOOST_DI_OPT_BUILD_TESTS "Build and perform Boost.DI tests" ${PROJECT_IS_TOP_LEVEL})
 
@@ -56,8 +58,10 @@ if(BOOST_DI_OPT_INSTALL)
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
 
-    install(
-        DIRECTORY ${CMAKE_SOURCE_DIR}/extension/include/
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    )
+    if(BOOST_DI_OPT_EXTENSION)
+        install(
+            DIRECTORY ${CMAKE_SOURCE_DIR}/extension/include/
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        )
+    endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(
     ${PROJECT_NAME} INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<$<BOOL:${USE_EXTENSION}>:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/extension/include>>
+    $<$<BOOL:${BOOST_DI_OPT_EXTENSION}>:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/extension/include>>
 )
 option(BOOST_DI_OPT_BUILD_TESTS "Build and perform Boost.DI tests" ${PROJECT_IS_TOP_LEVEL})
 


### PR DESCRIPTION
Problem:
VCPKG declare extensions as additional feature, which can be disabled.

Solution:
Adding CMake flag (default: ON) will simplify VCPKG port (currently, it is not installing library via CMake, instead copy files directly)
