### PR TITLE
fix error with clang 21

### DIFF
--- a/include/boost/di.hpp
+++ b/include/boost/di.hpp
@@ -2101,7 +2101,7 @@ struct binder {
   struct resolve__ {
     using type = decltype(resolve_impl__<TDefault, dependency_concept<aux::decay_t<T>, TName>>(aux::declval<TDeps*>()));
   };
-#if (defined(__CLANG__) && __CLANG__ >= 3'9)  //
+#if (defined(__CLANG__) && __CLANG__ >= 39)  //
   template <class TDeps, class T>
   static T& resolve_(TDeps* deps, const aux::type<T&>&) noexcept {
     return static_cast<T&>(*deps);
@@ -2124,7 +2124,7 @@ struct binder {
   template <class T, class TName = no_name, class TDefault = dependency<scopes::deduce, aux::decay_t<T>>, class TDeps>
   static decltype(auto) resolve(TDeps* deps) noexcept {
     using dependency = dependency_concept<aux::decay_t<T>, TName>;
-#if (defined(__CLANG__) && __CLANG__ >= 3'9)  //
+#if (defined(__CLANG__) && __CLANG__ >= 39)  //
     return resolve_(deps, aux::type<decltype(resolve_impl<TDefault, dependency>(aux::declval<TDeps*>()))>{});
 #else
     return resolve_impl<TDefault, dependency>(deps);

--- a/include/boost/di/core/binder.hpp
+++ b/include/boost/di/core/binder.hpp
@@ -49,7 +49,7 @@ struct binder {
   };
 
 /// Wknd for https://llvm.org/bugs/show_bug.cgi?id=28844
-#if (defined(__CLANG__) && __CLANG__ >= 3'9)  // __pph__
+#if (defined(__CLANG__) && __CLANG__ >= 39)  // __pph__
   template <class TDeps, class T>
   static T& resolve_(TDeps* deps, const aux::type<T&>&) noexcept {
     return static_cast<T&>(*deps);
@@ -78,7 +78,7 @@ struct binder {
     using dependency = dependency_concept<aux::decay_t<T>, TName>;
 
 /// Wknd for https://llvm.org/bugs/show_bug.cgi?id=28844
-#if (defined(__CLANG__) && __CLANG__ >= 3'9)  // __pph__
+#if (defined(__CLANG__) && __CLANG__ >= 39)  // __pph__
     return resolve_(deps, aux::type<decltype(resolve_impl<TDefault, dependency>(aux::declval<TDeps*>()))>{});
 #else   // __pph__
     return resolve_impl<TDefault, dependency>(deps);


### PR DESCRIPTION
boost-ext-di/include/boost/di.hpp:2104:42: error: token is not a valid binary operator in a preprocessor subexpression